### PR TITLE
docs: mention packaging version constraint

### DIFF
--- a/ENV_SETUP.md
+++ b/ENV_SETUP.md
@@ -25,9 +25,12 @@ pip install --upgrade pip
 ```
 
 ## Installing Dependencies
-Install all required packages from the project requirements file:
+Install all required packages from the project requirements file. Some packages
+need `packaging` below version 25, so install that first to avoid resolver
+errors:
 
 ```bash
+pip install "packaging<25"
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
## Summary
- clarify installation instructions for packaging

## Testing
- `python -c "import packaging, sys; print(packaging.__version__)"`


------
https://chatgpt.com/codex/tasks/task_e_6847ff25ca9c8323bcaf2b52b0b8577f