### PR TITLE
Implement agent workflow composition

### DIFF
--- a/legal_ai_system/core/agent_types.py
+++ b/legal_ai_system/core/agent_types.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import AsyncIterator, Generic, List, Protocol, TypeVar
+
+from pydantic import BaseModel
+
+T_Input = TypeVar("T_Input", bound=BaseModel)
+T_Output = TypeVar("T_Output", bound=BaseModel)
+T_Config = TypeVar("T_Config", bound=BaseModel)
+
+
+class ProcessingStrategy(str, Enum):
+    """Strategies supported by processing agents."""
+
+    HYBRID = "hybrid"  # Pattern + LLM
+    LLM_ONLY = "llm_only"
+    PATTERN_ONLY = "pattern_only"
+    ENSEMBLE = "ensemble"
+
+
+class AgentCapability(Protocol[T_Input, T_Output]):
+    """Protocol defining the core capabilities of an agent."""
+
+    async def process_batch(self, inputs: List[T_Input]) -> List[T_Output]:
+        """Process a batch of inputs and return a list of outputs."""
+
+    async def process_stream(
+        self, input_stream: AsyncIterator[T_Input]
+    ) -> AsyncIterator[T_Output]:
+        """Process a stream of inputs yielding outputs as they become available."""
+
+    def supports_capability(self, capability: str) -> bool:
+        """Return True if the agent supports the named capability."""
+
+
+__all__ = [
+    "ProcessingStrategy",
+    "AgentCapability",
+    "T_Input",
+    "T_Output",
+    "T_Config",
+]

--- a/legal_ai_system/tests/test_agent_workflow.py
+++ b/legal_ai_system/tests/test_agent_workflow.py
@@ -1,0 +1,68 @@
+import asyncio
+from typing import AsyncIterator, List
+
+import pytest
+from pydantic import BaseModel
+
+from legal_ai_system.core.agent_types import AgentCapability
+from legal_ai_system.workflows import AgentWorkflow
+
+
+class TextIn(BaseModel):
+    text: str
+
+
+class TextOut(BaseModel):
+    text: str
+
+
+class UpperAgent(AgentCapability[TextIn, TextOut]):
+    async def process_batch(self, inputs: List[TextIn]) -> List[TextOut]:
+        return [TextOut(text=i.text.upper()) for i in inputs]
+
+    async def process_stream(
+        self, input_stream: AsyncIterator[TextIn]
+    ) -> AsyncIterator[TextOut]:
+        async for item in input_stream:
+            yield TextOut(text=item.text.upper())
+
+    def supports_capability(self, capability: str) -> bool:  # pragma: no cover
+        return capability == "text"
+
+
+class SuffixAgent(AgentCapability[TextOut, TextOut]):
+    def __init__(self, suffix: str) -> None:
+        self.suffix = suffix
+
+    async def process_batch(self, inputs: List[TextOut]) -> List[TextOut]:
+        return [TextOut(text=i.text + self.suffix) for i in inputs]
+
+    async def process_stream(
+        self, input_stream: AsyncIterator[TextOut]
+    ) -> AsyncIterator[TextOut]:
+        async for item in input_stream:
+            yield TextOut(text=item.text + self.suffix)
+
+    def supports_capability(self, capability: str) -> bool:  # pragma: no cover
+        return capability == "text"
+
+
+@pytest.mark.asyncio
+async def test_workflow_batch() -> None:
+    wf = AgentWorkflow([UpperAgent(), SuffixAgent("!")])
+    result = await wf.process_batch([TextIn(text="hello")])
+    assert result[0].text == "HELLO!"
+
+
+@pytest.mark.asyncio
+async def test_workflow_stream() -> None:
+    wf = AgentWorkflow([UpperAgent(), SuffixAgent("!")])
+
+    async def gen() -> AsyncIterator[TextIn]:
+        yield TextIn(text="hello")
+
+    out = []
+    async for item in wf.process_stream(gen()):
+        out.append(item.text)
+
+    assert out == ["HELLO!"]

--- a/legal_ai_system/workflows/__init__.py
+++ b/legal_ai_system/workflows/__init__.py
@@ -1,1 +1,5 @@
+"""Workflow utilities and pipeline helpers."""
 
+from .agent_workflow import AgentWorkflow
+
+__all__ = ["AgentWorkflow"]

--- a/legal_ai_system/workflows/agent_workflow.py
+++ b/legal_ai_system/workflows/agent_workflow.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Iterable, List, Generic
+
+from ..core.agent_types import AgentCapability, T_Input, T_Output
+
+
+class AgentWorkflow(Generic[T_Input, T_Output]):
+    """Composable workflow that chains multiple agents."""
+
+    def __init__(
+        self, agents: Iterable[AgentCapability[Any, Any]] | None = None
+    ) -> None:
+        self.agents: List[AgentCapability[Any, Any]] = list(agents or [])
+
+    def add_agent(self, agent: AgentCapability[Any, Any]) -> None:
+        """Append an agent to the workflow."""
+
+        self.agents.append(agent)
+
+    async def process_batch(self, inputs: List[T_Input]) -> List[T_Output]:
+        """Process a batch of inputs sequentially through all agents."""
+
+        data: Any = inputs
+        for agent in self.agents:
+            data = await agent.process_batch(data)  # type: ignore[arg-type]
+        return data  # type: ignore[return-value]
+
+    async def process_stream(
+        self, input_stream: AsyncIterator[T_Input]
+    ) -> AsyncIterator[T_Output]:
+        """Process a stream of inputs through the chain of agents."""
+
+        stream: AsyncIterator[Any] = input_stream
+        for agent in self.agents:
+            stream = agent.process_stream(stream)  # type: ignore[assignment]
+        async for item in stream:
+            yield item  # type: ignore[misc]
+
+    def supports_capability(self, capability: str) -> bool:
+        """Check if all agents in the workflow support a given capability."""
+
+        return all(agent.supports_capability(capability) for agent in self.agents)
+
+
+__all__ = ["AgentWorkflow"]


### PR DESCRIPTION
## Summary
- add advanced generic agent types to express processing capabilities
- create `AgentWorkflow` to compose agents sequentially
- export new workflow helper
- test workflow composition

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848009a66f0832399703cc09c98861e