### PR TITLE
Add DocumentProcessorAgentV2

### DIFF
--- a/legal_ai_system/agents/document_processor_agent_v2.py
+++ b/legal_ai_system/agents/document_processor_agent_v2.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Generic, TypeVar
+
+from ..core.base_agent import BaseAgent, AgentError
+from ..core.detailed_logging import (
+    LogCategory,
+    detailed_log_function,
+    get_detailed_logger,
+)
+from ..utils.multimodal_types import (
+    MultiModalDocument,
+    AudioSegment,
+    DepositionTranscript,
+    StructuredForm,
+    RedlineAnalysis,
+)
+
+InputT = TypeVar("InputT", bound=Path)
+OutputT = TypeVar("OutputT", bound=MultiModalDocument)
+
+
+class DocumentProcessorAgentV2(BaseAgent, Generic[InputT, OutputT]):
+    """Enhanced document processor handling specialized legal content."""
+
+    @detailed_log_function(LogCategory.AGENT)
+    def __init__(self, service_container: Optional[Any] = None, **config: Any) -> None:
+        super().__init__(service_container, name="DocumentProcessorAgentV2", agent_type="document_processing")
+        if config:
+            self.config.update(config)
+        self.logger.info("DocumentProcessorAgentV2 initialized.")
+
+    async def _process_task(self, task_data: Path, metadata: Dict[str, Any]) -> MultiModalDocument:
+        """Trivial processing returning file contents as a ``MultiModalDocument``."""
+        try:
+            text = await asyncio.to_thread(Path(task_data).read_text, encoding="utf-8")
+        except Exception as exc:  # pragma: no cover - runtime errors
+            raise AgentError(f"Failed to read document: {exc}", self.name) from exc
+        return MultiModalDocument(text_content=text)
+
+    async def process_video_depositions(self, video_path: Path) -> DepositionTranscript:
+        """Extract audio and transcribe a deposition video."""
+        try:
+            from moviepy.editor import VideoFileClip  # type: ignore
+            import whisper  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional deps
+            raise AgentError("moviepy and whisper are required for video processing", self.name) from exc
+
+        audio_path = video_path.with_suffix(".wav")
+        await asyncio.to_thread(self._extract_audio, video_path, audio_path)
+        segments = await asyncio.to_thread(self._transcribe_audio, audio_path)
+        return DepositionTranscript(segments=segments, metadata={"source": str(video_path)})
+
+    def _extract_audio(self, video_path: Path, audio_path: Path) -> None:
+        from moviepy.editor import VideoFileClip  # type: ignore
+
+        clip = VideoFileClip(str(video_path))
+        clip.audio.write_audiofile(str(audio_path), logger=None)
+
+    def _transcribe_audio(self, audio_path: Path) -> List[AudioSegment]:
+        import whisper  # type: ignore
+
+        model = whisper.load_model("base")
+        result = model.transcribe(str(audio_path))
+        segments: List[AudioSegment] = []
+        for seg in result.get("segments", []):
+            segments.append(
+                AudioSegment(
+                    start_ms=int(seg["start"] * 1000),
+                    end_ms=int(seg["end"] * 1000),
+                    transcript=seg["text"].strip(),
+                )
+            )
+        return segments
+
+    async def process_legal_forms(self, form_path: Path) -> StructuredForm:
+        """Detect fields within legal forms (PDF or Excel)."""
+        if form_path.suffix.lower() == ".pdf":
+            try:
+                import pdfplumber  # type: ignore
+            except Exception as exc:  # pragma: no cover - optional dep
+                raise AgentError("pdfplumber required for PDF forms", self.name) from exc
+
+            fields: Dict[str, str] = {}
+            with pdfplumber.open(str(form_path)) as pdf:
+                for page in pdf.pages:
+                    for annot in page.annots or []:
+                        name = annot.get("field_name") or annot.get("Subtype")
+                        value = annot.get("field_value") or annot.get("Contents")
+                        if name:
+                            fields[str(name)] = str(value or "")
+        elif form_path.suffix.lower() in {".xlsx", ".xls"}:
+            try:
+                import openpyxl  # type: ignore
+            except Exception as exc:  # pragma: no cover
+                raise AgentError("openpyxl required for Excel forms", self.name) from exc
+
+            wb = openpyxl.load_workbook(form_path, data_only=True)
+            ws = wb.active
+            fields = {
+                str(r[0]): str(r[1])
+                for r in ws.iter_rows(min_col=1, max_col=2, values_only=True)
+                if r[0] is not None
+            }
+        else:
+            raise AgentError("Unsupported form type", self.name)
+
+        return StructuredForm(fields=fields, metadata={"source": str(form_path)})
+
+    async def process_contract_redlines(self, doc_path: Path) -> RedlineAnalysis:
+        """Parse tracked changes from a contract document."""
+        try:
+            import docx  # type: ignore
+            from lxml import etree  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional deps
+            raise AgentError("python-docx and lxml required for redline analysis", self.name) from exc
+
+        doc = docx.Document(str(doc_path))
+        root = etree.XML(doc._part.blob)
+        ns = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
+        additions = [el.text for el in root.iter(ns + "ins") if el.text]
+        deletions = [el.text for el in root.iter(ns + "del") if el.text]
+        comments = [el.text for el in root.iter(ns + "comment") if el.text]
+
+        return RedlineAnalysis(
+            additions=additions,
+            deletions=deletions,
+            comments=comments,
+            metadata={"source": str(doc_path)},
+        )

--- a/legal_ai_system/config/agent_unified_config.py
+++ b/legal_ai_system/config/agent_unified_config.py
@@ -14,6 +14,7 @@ from ..core.agent_unified_config import (
 )
 
 from ..agents.document_processor_agent import DocumentProcessorAgent
+from ..agents.document_processor_agent_v2 import DocumentProcessorAgentV2
 from ..agents.document_rewriter_agent import DocumentRewriterAgent
 from ..agents.ontology_extraction_agent import OntologyExtractionAgent
 from ..utils.hybrid_extractor import HybridLegalExtractor
@@ -22,6 +23,7 @@ from ..core.optimized_vector_store import OptimizedVectorStore
 from ..utils.reviewable_memory import ReviewableMemory
 
     "DocumentProcessorAgent": DocumentProcessorAgent,
+    "DocumentProcessorAgentV2": DocumentProcessorAgentV2,
     "DocumentRewriterAgent": DocumentRewriterAgent,
     "OntologyExtractionAgent": OntologyExtractionAgent,
     "HybridLegalExtractor": HybridLegalExtractor,

--- a/legal_ai_system/services/service_container.py
+++ b/legal_ai_system/services/service_container.py
@@ -769,6 +769,7 @@ async def create_service_container(
     # For now, let's assume workflows will get agent *classes* or factories.
     # Or, if agents are simple enough to be singletons:
     from ..agents.document_processor_agent import DocumentProcessorAgent
+    from ..agents.document_processor_agent_v2 import DocumentProcessorAgentV2
     from ..agents.document_rewriter_agent import DocumentRewriterAgent
     from ..agents.ontology_extraction_agent import OntologyExtractionAgent
     from ..agents.entity_extraction_agent import StreamlinedEntityExtractionAgent
@@ -780,6 +781,7 @@ async def create_service_container(
 
     agent_classes = {
         "document_processor_agent": DocumentProcessorAgent,
+        "document_processor_agent_v2": DocumentProcessorAgentV2,
         "ontology_extraction_agent": OntologyExtractionAgent,
         "streamlined_entity_extraction_agent": StreamlinedEntityExtractionAgent,
         # ... Add all other agent classes from agents/__init__.py

--- a/legal_ai_system/utils/multimodal_types.py
+++ b/legal_ai_system/utils/multimodal_types.py
@@ -75,6 +75,33 @@ class MultiModalDocument:
     metadata: DocumentMetadata = field(default_factory=DocumentMetadata)
 
 
+@dataclass
+class DepositionTranscript:
+    """Transcript produced from a video deposition."""
+
+    segments: List[AudioSegment] = field(default_factory=list)
+    speakers: Optional[List[str]] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class StructuredForm:
+    """Key/value representation of a legal form."""
+
+    fields: Dict[str, str] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RedlineAnalysis:
+    """Summary of contract revisions."""
+
+    additions: List[str] = field(default_factory=list)
+    deletions: List[str] = field(default_factory=list)
+    comments: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
 __all__ = [
     "ProcessedImage",
     "StructuredTable",
@@ -83,4 +110,7 @@ __all__ = [
     "VideoFrame",
     "DocumentMetadata",
     "MultiModalDocument",
+    "DepositionTranscript",
+    "StructuredForm",
+    "RedlineAnalysis",
 ]


### PR DESCRIPTION
## Summary
- create new dataclasses for deposition transcripts, structured forms, and redline analysis
- implement `DocumentProcessorAgentV2` with async processing helpers
- register new agent in agent config and service container

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848060eca848323bc5f0367a183b415