### PR TITLE
Add LegalReasoningEngine and config support

### DIFF
--- a/legal_ai_system/agents/legal_reasoning_engine.py
+++ b/legal_ai_system/agents/legal_reasoning_engine.py
@@ -1,0 +1,42 @@
+"""Legal Reasoning Engine
+=======================
+
+Minimal reasoning engine demonstrating structured analysis of legal issues.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from ..core.base_agent import BaseAgent
+from ..core.agent_unified_config import create_agent_memory_mixin
+
+MemoryMixin = create_agent_memory_mixin()
+
+
+@dataclass
+class LegalReasoningResult:
+    """Simple result structure for reasoning analysis."""
+
+    issue: str
+    conclusion: str
+    processed_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class LegalReasoningEngine(BaseAgent, MemoryMixin):
+    """Lightweight engine performing basic legal reasoning."""
+
+    def __init__(self, service_container: Any, **config: Any):
+        super().__init__(service_container, name="LegalReasoningEngine", agent_type="reasoning")
+        self.config = config
+
+    async def analyze(self, issue: str) -> LegalReasoningResult:
+        """Return a mock analysis for the provided issue."""
+        # A real implementation would leverage LLMs or rule-based reasoning
+        conclusion = f"Preliminary assessment for: {issue}"
+        return LegalReasoningResult(issue=issue, conclusion=conclusion)

--- a/legal_ai_system/core/configuration_manager.py
+++ b/legal_ai_system/core/configuration_manager.py
@@ -119,11 +119,26 @@ class ConfigurationManager:
                 return env_value_str
 
 
-        # Check if value exists in settings object
+        # Check if value exists in settings object directly
         if hasattr(self._settings, key):
             value = getattr(self._settings, key)
-            config_manager_logger.trace(f"Configuration value retrieved from settings object", parameters={'key': key, 'value_type': type(value).__name__})
+            config_manager_logger.trace(
+                f"Configuration value retrieved from settings object",
+                parameters={"key": key, "value_type": type(value).__name__},
+            )
             return value
+
+        # Support nested keys like "agents.legal_reasoning_engine_config"
+        if "." in key:
+            first, rest = key.split(".", 1)
+            if hasattr(self._settings, first):
+                sub_value = getattr(self._settings, first)
+                if isinstance(sub_value, dict) and rest in sub_value:
+                    config_manager_logger.trace(
+                        "Nested configuration value retrieved",
+                        parameters={"key": key},
+                    )
+                    return sub_value.get(rest, default)
         
         # Return default if key not found
         config_manager_logger.trace(f"Using default value for '{key}'", parameters={'default_value_type': type(default).__name__})

--- a/legal_ai_system/core/settings.py
+++ b/legal_ai_system/core/settings.py
@@ -6,7 +6,7 @@ Uses centralized constants to eliminate magic numbers.
 """
 
 from pathlib import Path
-from typing import List, Optional, Any, Union, cast
+from typing import List, Optional, Any, Union, cast, Dict
 
 try:
     from pydantic_settings import BaseSettings
@@ -137,6 +137,7 @@ except ImportError:
             "enable_test_mode": False,
             "enable_agent_debugging": False,
             "save_intermediate_results": False,
+            "agents": {"legal_reasoning_engine_config": {}},
         }
 
 
@@ -441,6 +442,12 @@ class LegalAISettings(BaseSettings):
     # =================== FRONTEND ===================
     frontend_dist_path: Optional[Path] = Field(
         default=None, env="FRONTEND_DIST_PATH"
+    )
+
+    # =================== AGENT CONFIGS ===================
+    agents: Dict[str, Any] = Field(
+        default_factory=lambda: {"legal_reasoning_engine_config": {}},
+        env="AGENTS_CONFIG",
     )
 
     class Config:

--- a/legal_ai_system/services/service_container.py
+++ b/legal_ai_system/services/service_container.py
@@ -772,6 +772,7 @@ async def create_service_container(
     from ..agents.document_rewriter_agent import DocumentRewriterAgent
     from ..agents.ontology_extraction_agent import OntologyExtractionAgent
     from ..agents.entity_extraction_agent import StreamlinedEntityExtractionAgent
+    from ..agents.legal_reasoning_engine import LegalReasoningEngine
 
     # Example: await container.register_service("document_processor_agent", instance=DocumentProcessorAgent(container))
     # This needs careful thought: are agents services or instantiated by workflows?
@@ -829,6 +830,7 @@ async def create_service_container(
             "KnowledgeBaseAgent",
             None,
         ),
+        "legal_reasoning_engine": LegalReasoningEngine,
     }
     for name, agent_cls in agent_classes.items():
         if agent_cls:  # Check if import was successful


### PR DESCRIPTION
## Summary
- implement new `LegalReasoningEngine` agent
- register `legal_reasoning_engine` in service container
- extend ConfigurationManager to resolve nested keys like `agents.<name>_config`
- expose agent configs via new `agents` field in settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848065f0c088323919eaadaf6d262dc