### PR TITLE
Update docs for typed workflow engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,44 @@ Alternatively, run the helper script to automate the setup and validation:
 python scripts/setup_environment_task.py
 ```
 
-
+```bash
 npm install
 npm run build
+```
+
+## Example: Building a Workflow
+
+Below is a minimal example using `LegalWorkflowBuilder` to create a typed
+workflow composed of two agents.  Each agent defines its input and output
+models so the builder can verify compatibility.
+
+```python
+from legal_ai_system.workflows.builder import LegalWorkflowBuilder
+from legal_ai_system.agents.entity_extraction_agent import EntityExtractionAgent
+from legal_ai_system.agents.text_correction_agent import TextCorrectionAgent
+from pydantic import BaseModel
+import asyncio
+
+
+class TextIn(BaseModel):
+    text: str
+
+
+class TextOut(BaseModel):
+    text: str
+
+
+async def main() -> None:
+    builder = LegalWorkflowBuilder[TextIn, TextOut]()
+    builder.add_agent(EntityExtractionAgent())
+    builder.add_agent(TextCorrectionAgent())
+    workflow = builder.build()
+    result = await workflow.process_batch([TextIn(text="Example")])
+    print(result[0].text)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 

--- a/docs/system_layout.md
+++ b/docs/system_layout.md
@@ -75,6 +75,18 @@ During processing:
 
 LangGraph based workflows use `AnalysisNode` and `SummaryNode` (see `agents/agent_nodes.py`) which internally retrieve the integration service via the service container to run analysis or summarization.  This allows complex graphs of tasks to be executed with consistent resource management.
 
+### Typed Workflow Engine
+
+The project includes a lightweight typed workflow engine located in
+`legal_ai_system.workflows`.  Agents implement the generic protocol
+`AgentCapability[InputModel, OutputModel]` from
+`legal_ai_system.core.agent_types`.  The `LegalWorkflowBuilder` class
+assembles agents while verifying that the output type of one agent
+matches the input type of the next.  Calling
+`LegalWorkflowBuilder.build()` produces an `AgentWorkflow` object from
+`legal_ai_system.workflows.agent_workflow` which can process batches or
+streams asynchronously.
+
 Overall, the ServiceContainer acts as the hub connecting agents and services, enabling workflows like `RealTimeAnalysisWorkflow` and integration via APIs or GUI components.
 
 ### `handle_document_upload` response


### PR DESCRIPTION
## Summary
- document typed workflow engine in system layout
- fix README formatting and add LegalWorkflowBuilder example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684806725b888323a72eb206756529e7