### PR TITLE
Add workflow builder and realtime workflow tests

### DIFF
--- a/legal_ai_system/services/realtime_analysis_workflow.py
+++ b/legal_ai_system/services/realtime_analysis_workflow.py
@@ -93,6 +93,8 @@ class RealTimeAnalysisWorkflow:
     - Performance monitoring and optimization
     """
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - stub
+        """Create an empty workflow instance for testing."""
 
         # Performance tracking
         self.documents_processed = 0

--- a/legal_ai_system/tests/test_realtime_workflow_refactor.py
+++ b/legal_ai_system/tests/test_realtime_workflow_refactor.py
@@ -1,0 +1,144 @@
+import asyncio
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+import sys
+
+import pytest
+
+# Stub heavy optional dependencies before importing workflow module
+for name in [
+    "aioredis",
+    "aioredis.client",
+    "aioredis.connection",
+    "aioredis.exceptions",
+    "spacy",
+    "spacy.language",
+    "spacy.tokens",
+    "numpy",
+    "sklearn",
+    "sklearn.metrics",
+    "sklearn.metrics.pairwise",
+]:
+    if name not in sys.modules:
+        sys.modules[name] = ModuleType(name)
+
+class _RedisError(Exception):
+    pass
+
+sys.modules["aioredis"].Redis = object
+sys.modules["aioredis"].StrictRedis = object
+exc = ModuleType("exceptions")
+exc.RedisError = _RedisError
+exc.TimeoutError = TimeoutError = type("TimeoutError", (Exception,), {})
+sys.modules["aioredis.exceptions"] = exc
+sys.modules["sklearn.metrics.pairwise"].cosine_similarity = lambda *a, **k: []
+if not hasattr(sys.modules["numpy"], "array"):
+    sys.modules["numpy"].array = lambda *a, **k: a
+if not hasattr(sys.modules["spacy.tokens"], "Doc"):
+    sys.modules["spacy.tokens"].Doc = object
+    sys.modules["spacy.tokens"].Span = object
+    sys.modules["spacy.tokens"].SpanGroup = object
+if not hasattr(sys.modules["spacy.language"], "Language"):
+    sys.modules["spacy.language"].Language = object
+svc_mod = sys.modules.setdefault(
+    "legal_ai_system.services.service_container", ModuleType("service_container")
+)
+class ServiceContainer:  # minimal stub
+    pass
+svc_mod.ServiceContainer = ServiceContainer
+
+from legal_ai_system.services.realtime_analysis_workflow import (
+    RealTimeAnalysisWorkflow,
+    RealTimeAnalysisResult,
+)
+
+
+class DummyWorkflow(RealTimeAnalysisWorkflow):
+    def __init__(self):
+        # Set minimal attributes without calling super().__init__
+        self.processing_lock = asyncio.Semaphore(1)
+        self.logger = MagicMock()
+        self.max_concurrent_documents = 1
+        self.auto_optimization_threshold = 1000
+        self.documents_processed = 0
+        self.progress_callbacks = []
+        self.update_callbacks = []
+        self.enable_real_time_sync = False
+
+        self.document_processor = SimpleNamespace(
+            process=AsyncMock(return_value=SimpleNamespace(data=SimpleNamespace(content="txt", success=True)))
+        )
+        self.document_rewriter = SimpleNamespace(
+            rewrite_text=AsyncMock(return_value=SimpleNamespace(corrected_text="txt"))
+        )
+        self.hybrid_extractor = SimpleNamespace(
+            extract_from_document=AsyncMock(return_value=SimpleNamespace(validated_entities=[], targeted_extractions={}, document_id="d")),
+            initialize=AsyncMock(),
+            close=AsyncMock(),
+        )
+        self.ontology_extractor = SimpleNamespace(
+            process=AsyncMock(return_value=SimpleNamespace(entities=[], relationships=[]))
+        )
+        self.graph_manager = SimpleNamespace(
+            initialize_service=AsyncMock(),
+            close=AsyncMock(),
+            get_realtime_stats=AsyncMock(return_value={}),
+        )
+        self.vector_store = SimpleNamespace(
+            initialize=AsyncMock(),
+            close=AsyncMock(),
+            add_vector_async=AsyncMock(return_value=None),
+            optimize_performance=AsyncMock(return_value={}),
+            get_service_status=AsyncMock(return_value={}),
+        )
+        self.reviewable_memory = SimpleNamespace(
+            initialize=AsyncMock(),
+            close=AsyncMock(),
+            process_extraction_result=AsyncMock(return_value={}),
+            get_pending_reviews_async=AsyncMock(return_value=[]),
+            get_review_stats_async=AsyncMock(return_value={}),
+            submit_review_decision_async=AsyncMock(return_value=True),
+        )
+
+        # Patch internal helpers
+        self._notify_progress = AsyncMock()
+        self._notify_update = AsyncMock()
+        self._process_entities_realtime = AsyncMock(return_value={})
+        self._update_vector_store_realtime = AsyncMock(return_value={})
+        self._integrate_with_memory = AsyncMock(return_value={})
+        self._validate_extraction_quality = AsyncMock(return_value={})
+        self._calculate_confidence_scores = MagicMock(return_value={})
+        self._get_sync_status = AsyncMock(return_value={})
+        self._update_performance_stats = AsyncMock()
+        self._auto_optimize_system = AsyncMock()
+        self._create_legal_document = MagicMock(
+            side_effect=lambda result, path, doc_id, text_override=None: SimpleNamespace(
+                id=doc_id,
+                file_path=path,
+                content=text_override or result.get("content", ""),
+                metadata={"processing_result": result},
+            )
+        )
+        self._extract_text_from_result = MagicMock(return_value="txt")
+
+
+@pytest.mark.asyncio
+async def test_process_document_realtime_returns_result_structure() -> None:
+    wf = DummyWorkflow()
+    result = await wf.process_document_realtime("sample.txt")
+
+    assert isinstance(result, RealTimeAnalysisResult)
+    data = result.to_dict()
+    expected_keys = {
+        "document_path",
+        "document_id",
+        "processing_times",
+        "total_processing_time",
+        "confidence_scores",
+        "validation_results",
+        "sync_status",
+        "graph_updates",
+        "vector_updates",
+        "memory_updates",
+    }
+    assert expected_keys.issubset(set(data.keys()))

--- a/legal_ai_system/tests/test_workflow_builder.py
+++ b/legal_ai_system/tests/test_workflow_builder.py
@@ -1,0 +1,78 @@
+import asyncio
+from typing import Any
+
+import pytest
+
+from legal_ai_system.utils.workflow_builder import WorkflowBuilder
+
+
+@pytest.mark.asyncio
+async def test_node_registration_and_execution() -> None:
+    builder = WorkflowBuilder()
+
+    async def start(x: int) -> int:
+        return x + 1
+
+    builder.register_node("start", start)
+    builder.set_entry_point("start")
+
+    result = await builder.run(1)
+    assert result == 2
+
+
+@pytest.mark.asyncio
+async def test_conditional_branching() -> None:
+    builder = WorkflowBuilder()
+
+    async def start(x: int) -> int:
+        return x
+
+    async def pos(x: int) -> int:
+        return x + 1
+
+    async def neg(x: int) -> int:
+        return x - 1
+
+    builder.register_node("start", start)
+    builder.register_node("pos", pos)
+    builder.register_node("neg", neg)
+    builder.set_entry_point("start")
+    builder.add_edge("start", "pos", condition=lambda v: v > 0)
+    builder.add_edge("start", "neg", condition=lambda v: v <= 0)
+
+    result = await builder.run(5)
+    assert result == 6
+
+
+@pytest.mark.asyncio
+async def test_parallel_execution_and_merge() -> None:
+    builder = WorkflowBuilder()
+    calls: dict[str, int] = {"a": 0, "b": 0}
+
+    async def start(x: int) -> int:
+        return x
+
+    async def node_a(x: int) -> int:
+        calls["a"] += 1
+        await asyncio.sleep(0.01)
+        return x + 1
+
+    async def node_b(x: int) -> int:
+        calls["b"] += 1
+        await asyncio.sleep(0.01)
+        return x + 2
+
+    async def merge(results: list[int]) -> int:
+        return sum(results)
+
+    builder.register_node("start", start)
+    builder.register_node("a", node_a)
+    builder.register_node("b", node_b)
+    builder.register_node("merge", merge)
+
+    builder.set_entry_point("start")
+    builder.add_parallel("start", ["a", "b"], "merge")
+
+    result = await builder.run(0)
+    assert result == 3
+    assert calls == {"a": 1, "b": 1}

--- a/legal_ai_system/utils/workflow_builder.py
+++ b/legal_ai_system/utils/workflow_builder.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Callable, Dict, List, Optional, Tuple, Awaitable
+
+
+class WorkflowBuilder:
+    """Simple asynchronous workflow builder supporting branching and merges."""
+
+    def __init__(self) -> None:
+        self._nodes: Dict[str, Callable[[Any], Awaitable[Any]]] = {}
+        self._entry: Optional[str] = None
+        self._transitions: Dict[str, List[Tuple[str, Optional[Callable[[Any], bool]], bool]]] = {}
+        self._parallel: Dict[str, Tuple[List[str], str]] = {}
+
+    def register_node(self, name: str, func: Callable[[Any], Awaitable[Any]]) -> None:
+        self._nodes[name] = func
+
+    def set_entry_point(self, name: str) -> None:
+        self._entry = name
+
+    def add_edge(
+        self,
+        start: str,
+        end: str,
+        condition: Optional[Callable[[Any], bool]] = None,
+        parallel: bool = False,
+    ) -> None:
+        self._transitions.setdefault(start, []).append((end, condition, parallel))
+
+    def add_parallel(self, start: str, branches: List[str], merge: str) -> None:
+        self._parallel[start] = (branches, merge)
+
+    async def run(self, data: Any) -> Any:
+        if self._entry is None:
+            raise RuntimeError("Entry point not set")
+        return await self._execute(self._entry, data)
+
+    async def _execute(self, node_name: str, data: Any) -> Any:
+        node = self._nodes[node_name]
+        result = await node(data)
+
+        if node_name in self._parallel:
+            branches, merge_node = self._parallel[node_name]
+            branch_results = await asyncio.gather(
+                *[self._execute(b, result) for b in branches]
+            )
+            result = await self._nodes[merge_node](branch_results)
+            node_name = merge_node
+
+        for next_node, cond, parallel in self._transitions.get(node_name, []):
+            if cond is None or cond(result):
+                if parallel:
+                    asyncio.create_task(self._execute(next_node, result))
+                else:
+                    result = await self._execute(next_node, result)
+        return result
+
+__all__ = ["WorkflowBuilder"]


### PR DESCRIPTION
## Summary
- implement `WorkflowBuilder` utility with branching and parallelism
- fix `RealTimeAnalysisWorkflow` stub for import
- add unit tests for `WorkflowBuilder`
- add unit test for realtime workflow using mocked services

## Testing
- `pytest legal_ai_system/tests/test_workflow_builder.py legal_ai_system/tests/test_realtime_workflow_refactor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684806719a9883238e36afdbf48d9617