### PR TITLE
Add workflow engine utilities

### DIFF
--- a/legal_ai_system/workflow_engine/__init__.py
+++ b/legal_ai_system/workflow_engine/__init__.py
@@ -1,0 +1,17 @@
+"""Workflow engine utilities for building async workflows."""
+
+from .builder import LegalWorkflowBuilder
+from .retry import ExponentialBackoffRetry
+from .merge import ConcatMerge, DictUpdateMerge
+from .types import WorkflowContext, LegalWorkflowNode, MergeStrategy, RetryStrategy
+
+__all__ = [
+    "LegalWorkflowBuilder",
+    "ExponentialBackoffRetry",
+    "ConcatMerge",
+    "DictUpdateMerge",
+    "WorkflowContext",
+    "LegalWorkflowNode",
+    "MergeStrategy",
+    "RetryStrategy",
+]

--- a/legal_ai_system/workflow_engine/builder.py
+++ b/legal_ai_system/workflow_engine/builder.py
@@ -1,0 +1,96 @@
+"""Composable workflow builder supporting branches and parallel execution."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable, Iterable, List, Optional
+
+from .merge import ConcatMerge
+from .types import (
+    LegalWorkflowNode,
+    MergeStrategy,
+    RetryStrategy,
+    WorkflowContext,
+)
+
+
+class LegalWorkflowBuilder:
+    """Build and execute asynchronous workflows."""
+
+    def __init__(
+        self,
+        retry_strategy: RetryStrategy | None = None,
+    ) -> None:
+        self._steps: List[Callable[[Any, WorkflowContext], Awaitable[Any]]] = []
+        self._retry = retry_strategy
+
+    # -----------------------------------------------------
+    async def _run_node(
+        self, node: LegalWorkflowNode[Any, Any], data: Any, ctx: WorkflowContext
+    ) -> Any:
+        if self._retry is not None:
+            return await self._retry.execute(node.run, data, ctx)
+        return await node.run(data, ctx)
+
+    # -----------------------------------------------------
+    def add_node(self, node: LegalWorkflowNode[Any, Any]) -> "LegalWorkflowBuilder":
+        """Append a node to the workflow."""
+
+        async def step(data: Any, ctx: WorkflowContext) -> Any:
+            return await self._run_node(node, data, ctx)
+
+        self._steps.append(step)
+        return self
+
+    # -----------------------------------------------------
+    def add_conditional(
+        self,
+        predicate: Callable[[Any, WorkflowContext], Awaitable[bool] | bool],
+        true_branch: "LegalWorkflowBuilder",
+        false_branch: Optional["LegalWorkflowBuilder"] = None,
+    ) -> "LegalWorkflowBuilder":
+        """Execute branches based on a predicate."""
+
+        async def step(data: Any, ctx: WorkflowContext) -> Any:
+            pred = predicate(data, ctx)
+            if asyncio.iscoroutine(pred):
+                pred = await pred  # type: ignore[assignment]
+            if pred:
+                return await true_branch.execute(data, ctx)
+            if false_branch is not None:
+                return await false_branch.execute(data, ctx)
+            return data
+
+        self._steps.append(step)
+        return self
+
+    # -----------------------------------------------------
+    def add_parallel(
+        self,
+        nodes: Iterable[LegalWorkflowNode[Any, Any]],
+        merge: MergeStrategy | None = None,
+    ) -> "LegalWorkflowBuilder":
+        """Run a group of nodes concurrently and merge their results."""
+
+        strategy = merge or ConcatMerge()
+
+        async def step(data: Any, ctx: WorkflowContext) -> Any:
+            tasks = [self._run_node(node, data, ctx) for node in nodes]
+            results = await asyncio.gather(*tasks)
+            return await strategy.merge(results)
+
+        self._steps.append(step)
+        return self
+
+    # -----------------------------------------------------
+    async def execute(
+        self, data: Any, context: WorkflowContext | None = None
+    ) -> Any:
+        """Run the workflow against ``data``."""
+
+        ctx = context or WorkflowContext()
+        result: Any = data
+        for step in self._steps:
+            result = await step(result, ctx)
+        return result
+

--- a/legal_ai_system/workflow_engine/merge.py
+++ b/legal_ai_system/workflow_engine/merge.py
@@ -1,0 +1,29 @@
+"""Merge strategies for results from parallel workflow branches."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Sequence
+
+from .types import MergeStrategy
+
+
+class ConcatMerge(MergeStrategy[List[Any]]):
+    """Merge lists by concatenation."""
+
+    async def merge(self, results: Sequence[List[Any]]) -> List[Any]:
+        merged: List[Any] = []
+        for result in results:
+            merged.extend(result)
+        return merged
+
+
+class DictUpdateMerge(MergeStrategy[Dict[str, Any]]):
+    """Merge dictionaries using ``dict.update`` semantics."""
+
+    async def merge(
+        self, results: Sequence[Mapping[str, Any]]
+    ) -> Dict[str, Any]:
+        merged: Dict[str, Any] = {}
+        for result in results:
+            merged.update(result)
+        return merged

--- a/legal_ai_system/workflow_engine/models.py
+++ b/legal_ai_system/workflow_engine/models.py
@@ -1,0 +1,19 @@
+"""Pydantic models for workflow inputs and outputs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class NodeInput(BaseModel):
+    """Base model for inputs to workflow nodes."""
+
+    payload: Any = Field(..., description="Input payload")
+
+
+class NodeOutput(BaseModel):
+    """Base model for outputs from workflow nodes."""
+
+    result: Any = Field(..., description="Output result")

--- a/legal_ai_system/workflow_engine/retry.py
+++ b/legal_ai_system/workflow_engine/retry.py
@@ -1,0 +1,34 @@
+"""Retry strategies for workflow nodes."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable, TypeVar
+
+from .types import RetryStrategy
+
+T = TypeVar("T")
+
+
+class ExponentialBackoffRetry(RetryStrategy):
+    """Retry strategy using exponential backoff."""
+
+    def __init__(self, attempts: int = 3, base_delay: float = 0.5) -> None:
+        self.attempts = attempts
+        self.base_delay = base_delay
+
+    async def execute(
+        self, func: Callable[..., Awaitable[T]], *args: Any, **kwargs: Any
+    ) -> T:
+        last_exc: BaseException | None = None
+        for attempt in range(1, self.attempts + 1):
+            try:
+                return await func(*args, **kwargs)
+            except Exception as exc:  # noqa: BLE001 - propagate after retries
+                last_exc = exc
+                if attempt == self.attempts:
+                    break
+                delay = self.base_delay * 2 ** (attempt - 1)
+                await asyncio.sleep(delay)
+        assert last_exc is not None
+        raise last_exc

--- a/legal_ai_system/workflow_engine/types.py
+++ b/legal_ai_system/workflow_engine/types.py
@@ -1,0 +1,42 @@
+"""Core typing utilities for the workflow engine."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Protocol, Sequence, TypeVar, Generic, Callable
+
+T = TypeVar("T")
+T_In = TypeVar("T_In")
+T_Out = TypeVar("T_Out")
+
+
+@dataclass
+class WorkflowContext:
+    """Container for passing metadata and shared state between nodes."""
+
+    data: dict[str, Any] = field(default_factory=dict)
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+class RetryStrategy(Protocol):
+    """Protocol for retrying operations."""
+
+    async def execute(
+        self, func: Callable[..., Awaitable[T]], *args: Any, **kwargs: Any
+    ) -> T:
+        """Execute ``func`` with retry semantics and return its result."""
+
+
+class MergeStrategy(Protocol, Generic[T]):
+    """Protocol for merging multiple results into one."""
+
+    async def merge(self, results: Sequence[T]) -> T:
+        """Merge a sequence of ``results`` and return a single value."""
+
+
+class LegalWorkflowNode(Protocol, Generic[T_In, T_Out]):
+    """Unit of work executed within a workflow."""
+
+    async def run(self, data: T_In, context: WorkflowContext) -> T_Out:
+        """Process ``data`` returning an output."""


### PR DESCRIPTION
## Summary
- create `workflow_engine` package
- define protocol types and retry/merge strategies
- implement `LegalWorkflowBuilder` for async workflows
- include optional pydantic models for node IO
- expose components via package `__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684807dd99e083238e4de490160f09ba