### PR TITLE
Add KnowledgeGraphReasoningAgent tests

### DIFF
--- a/legal_ai_system/agents/knowledge_graph_reasoning_agent.py
+++ b/legal_ai_system/agents/knowledge_graph_reasoning_agent.py
@@ -1,0 +1,88 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+from ..services.knowledge_graph_manager import (
+    KnowledgeGraphManager,
+    Entity,
+    RelationshipType,
+)
+
+
+@dataclass
+class ConnectedEntities:
+    """Result for connected entities query."""
+
+    entity: Entity
+    connected: List[Entity]
+
+
+@dataclass
+class CaseEntities:
+    """Entities involved in a case."""
+
+    case: Entity
+    entities: List[Entity]
+
+
+@dataclass
+class PathResult:
+    """Shortest path between two entities."""
+
+    source: Entity
+    target: Entity
+    path: List[Entity]
+
+
+class KnowledgeGraphReasoningAgent:
+    """Lightweight reasoning agent over the knowledge graph."""
+
+    def __init__(self, kg_manager: KnowledgeGraphManager) -> None:
+        self.kg_manager = kg_manager
+
+    async def get_connected_entities(self, entity_id: str) -> ConnectedEntities:
+        entity = await self.kg_manager.get_entity(entity_id)
+        connected = await self.kg_manager.find_connected_entities(entity_id)
+        return ConnectedEntities(entity=entity, connected=connected)
+
+    async def get_case_entities(self, case_id: str) -> CaseEntities:
+        case = await self.kg_manager.get_entity(case_id)
+        involved: List[Entity] = []
+        for rel in self.kg_manager.relationships.values():
+            if rel.source_entity_id == case_id and rel.type == RelationshipType.INVOLVES:
+                ent = await self.kg_manager.get_entity(rel.target_entity_id)
+                if ent:
+                    involved.append(ent)
+            elif rel.target_entity_id == case_id and rel.type == RelationshipType.INVOLVES:
+                ent = await self.kg_manager.get_entity(rel.source_entity_id)
+                if ent:
+                    involved.append(ent)
+        return CaseEntities(case=case, entities=involved)
+
+    async def shortest_path(
+        self, source_id: str, target_id: str, max_depth: int = 3
+    ) -> Optional[PathResult]:
+        if source_id == target_id:
+            ent = await self.kg_manager.get_entity(source_id)
+            return PathResult(source=ent, target=ent, path=[ent])
+
+        from collections import deque
+
+        queue = deque([(source_id, [source_id])])
+        visited = {source_id}
+        while queue:
+            current, path = queue.popleft()
+            if len(path) > max_depth:
+                continue
+            if current == target_id:
+                entities = [await self.kg_manager.get_entity(eid) for eid in path]
+                return PathResult(source=entities[0], target=entities[-1], path=entities)
+            for rel in self.kg_manager.relationships.values():
+                next_id = None
+                if rel.source_entity_id == current:
+                    next_id = rel.target_entity_id
+                elif rel.target_entity_id == current:
+                    next_id = rel.source_entity_id
+                if next_id and next_id not in visited:
+                    visited.add(next_id)
+                    queue.append((next_id, path + [next_id]))
+        return None

--- a/legal_ai_system/tests/test_knowledge_graph_reasoning_agent.py
+++ b/legal_ai_system/tests/test_knowledge_graph_reasoning_agent.py
@@ -1,0 +1,87 @@
+import asyncio
+from typing import Dict
+
+import pytest
+
+from legal_ai_system.agents.knowledge_graph_reasoning_agent import (
+    KnowledgeGraphReasoningAgent,
+    ConnectedEntities,
+    CaseEntities,
+    PathResult,
+)
+from legal_ai_system.services.knowledge_graph_manager import (
+    Entity,
+    Relationship,
+    EntityType,
+    RelationshipType,
+)
+
+
+class DummyKG:
+    def __init__(self) -> None:
+        self.entities: Dict[str, Entity] = {}
+        self.relationships: Dict[str, Relationship] = {}
+
+    async def get_entity(self, entity_id: str):
+        return self.entities.get(entity_id)
+
+    async def find_connected_entities(self, entity_id: str, relationship_types=None, max_depth=2):
+        connected = set()
+        for rel in self.relationships.values():
+            if rel.source_entity_id == entity_id:
+                connected.add(rel.target_entity_id)
+            elif rel.target_entity_id == entity_id:
+                connected.add(rel.source_entity_id)
+        return [self.entities[eid] for eid in connected]
+
+
+def build_dummy_graph() -> DummyKG:
+    kg = DummyKG()
+    e1 = Entity(id="p1", type=EntityType.PERSON, name="Alice")
+    e2 = Entity(id="c1", type=EntityType.CASE, name="CaseA")
+    e3 = Entity(id="o1", type=EntityType.ORGANIZATION, name="ACME")
+    kg.entities = {e.id: e for e in [e1, e2, e3]}
+    r1 = Relationship(
+        id="r1",
+        source_entity_id="p1",
+        target_entity_id="c1",
+        type=RelationshipType.INVOLVES,
+    )
+    r2 = Relationship(
+        id="r2",
+        source_entity_id="c1",
+        target_entity_id="o1",
+        type=RelationshipType.INVOLVES,
+    )
+    kg.relationships = {r1.id: r1, r2.id: r2}
+    return kg
+
+
+@pytest.mark.asyncio
+async def test_get_connected_entities():
+    kg = build_dummy_graph()
+    agent = KnowledgeGraphReasoningAgent(kg)
+    result = await agent.get_connected_entities("c1")
+    assert isinstance(result, ConnectedEntities)
+    names = {e.name for e in result.connected}
+    assert names == {"Alice", "ACME"}
+
+
+@pytest.mark.asyncio
+async def test_get_case_entities():
+    kg = build_dummy_graph()
+    agent = KnowledgeGraphReasoningAgent(kg)
+    result = await agent.get_case_entities("c1")
+    assert isinstance(result, CaseEntities)
+    names = {e.name for e in result.entities}
+    assert names == {"Alice", "ACME"}
+
+
+@pytest.mark.asyncio
+async def test_shortest_path():
+    kg = build_dummy_graph()
+    agent = KnowledgeGraphReasoningAgent(kg)
+    result = await agent.shortest_path("p1", "o1")
+    assert isinstance(result, PathResult)
+    path_names = [e.name for e in result.path]
+    assert path_names == ["Alice", "CaseA", "ACME"]


### PR DESCRIPTION
## Summary
- add `KnowledgeGraphReasoningAgent` with basic reasoning helpers
- add unit tests for reasoning agent using a mocked graph

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684806872c90832384ca3171e40b5d66