### PR TITLE
Add workflow_engine package

### DIFF
--- a/legal_ai_system/workflow_engine/__init__.py
+++ b/legal_ai_system/workflow_engine/__init__.py
@@ -1,0 +1,17 @@
+"""Minimal workflow engine utilities."""
+
+from .types import WorkflowContext, RetryStrategy, MergeStrategy, LegalWorkflowNode
+from .retry import ExponentialBackoffRetry
+from .merge import ConcatMerge, DictUpdateMerge
+from .builder import LegalWorkflowBuilder
+
+__all__ = [
+    "WorkflowContext",
+    "RetryStrategy",
+    "MergeStrategy",
+    "LegalWorkflowNode",
+    "ExponentialBackoffRetry",
+    "ConcatMerge",
+    "DictUpdateMerge",
+    "LegalWorkflowBuilder",
+]

--- a/legal_ai_system/workflow_engine/builder.py
+++ b/legal_ai_system/workflow_engine/builder.py
@@ -1,0 +1,122 @@
+"""Composable workflow builder."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Iterable, List, Sequence
+
+from .merge import ConcatMerge
+from .types import (
+    LegalWorkflowNode,
+    MergeStrategy,
+    RetryStrategy,
+    WorkflowContext,
+)
+
+
+@dataclass
+class _SequentialNode(LegalWorkflowNode[Any, Any]):
+    nodes: Sequence[LegalWorkflowNode[Any, Any]]
+
+    async def run(self, data: Any, context: WorkflowContext) -> Any:
+        result: Any = data
+        for node in self.nodes:
+            result = await node.run(result, context)
+        return result
+
+
+@dataclass
+class _RetryNode(LegalWorkflowNode[Any, Any]):
+    node: LegalWorkflowNode[Any, Any]
+    strategy: RetryStrategy
+
+    async def run(self, data: Any, context: WorkflowContext) -> Any:
+        attempt = 0
+        while True:
+            try:
+                return await self.node.run(data, context)
+            except Exception as exc:  # pragma: no cover - simple retry wrapper
+                attempt += 1
+                delay = await self.strategy.should_retry(attempt, exc, context)
+                if delay is None:
+                    raise
+                await asyncio.sleep(delay)
+
+
+@dataclass
+class _ParallelNode(LegalWorkflowNode[Any, Any]):
+    nodes: Sequence[LegalWorkflowNode[Any, Any]]
+    merge: MergeStrategy[Any] = ConcatMerge()
+
+    async def run(self, data: Any, context: WorkflowContext) -> Any:
+        results = await asyncio.gather(
+            *(node.run(data, context) for node in self.nodes)
+        )
+        return await self.merge.merge(results)
+
+
+@dataclass
+class _BranchNode(LegalWorkflowNode[Any, Any]):
+    condition: Callable[[Any, WorkflowContext], Awaitable[bool]]
+    if_true: LegalWorkflowNode[Any, Any]
+    if_false: LegalWorkflowNode[Any, Any] | None = None
+
+    async def run(self, data: Any, context: WorkflowContext) -> Any:
+        if await self.condition(data, context):
+            return await self.if_true.run(data, context)
+        if self.if_false:
+            return await self.if_false.run(data, context)
+        return data
+
+
+class LegalWorkflowBuilder:
+    """Utility to compose complex workflows."""
+
+    def __init__(self) -> None:
+        self._nodes: List[LegalWorkflowNode[Any, Any]] = []
+
+    def add_node(
+        self,
+        node: LegalWorkflowNode[Any, Any],
+        *,
+        retry: RetryStrategy | None = None,
+    ) -> "LegalWorkflowBuilder":
+        if retry:
+            node = _RetryNode(node=node, strategy=retry)
+        self._nodes.append(node)
+        return self
+
+    def add_conditional(
+        self,
+        condition: Callable[[Any, WorkflowContext], Awaitable[bool]],
+        true_branch: "LegalWorkflowBuilder",
+        false_branch: "LegalWorkflowBuilder" | None = None,
+    ) -> "LegalWorkflowBuilder":
+        branch_node = _BranchNode(
+            condition=condition,
+            if_true=true_branch.build(),
+            if_false=false_branch.build() if false_branch else None,
+        )
+        self._nodes.append(branch_node)
+        return self
+
+    def add_parallel(
+        self,
+        nodes: Iterable[LegalWorkflowNode[Any, Any]],
+        *,
+        merge: MergeStrategy[Any] | None = None,
+    ) -> "LegalWorkflowBuilder":
+        parallel_node = _ParallelNode(
+            nodes=list(nodes),
+            merge=merge or ConcatMerge(),
+        )
+        self._nodes.append(parallel_node)
+        return self
+
+    def build(self) -> LegalWorkflowNode[Any, Any]:
+        return _SequentialNode(self._nodes)
+
+    async def run(self, data: Any, context: WorkflowContext | None = None) -> Any:
+        ctx = context or WorkflowContext()
+        return await self.build().run(data, ctx)

--- a/legal_ai_system/workflow_engine/merge.py
+++ b/legal_ai_system/workflow_engine/merge.py
@@ -1,0 +1,29 @@
+"""Merge strategies for combining parallel results."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence, TypeVar
+
+from .types import MergeStrategy
+
+T = TypeVar("T")
+
+
+class ConcatMerge(MergeStrategy[List[T]]):
+    """Concatenate lists from parallel executions."""
+
+    async def merge(self, results: Sequence[List[T]]) -> List[T]:
+        merged: List[T] = []
+        for item in results:
+            merged.extend(item)
+        return merged
+
+
+class DictUpdateMerge(MergeStrategy[Dict[str, Any]]):
+    """Merge dictionaries by updating keys."""
+
+    async def merge(self, results: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+        merged: Dict[str, Any] = {}
+        for d in results:
+            merged.update(d)
+        return merged

--- a/legal_ai_system/workflow_engine/models.py
+++ b/legal_ai_system/workflow_engine/models.py
@@ -1,0 +1,18 @@
+"""Optional pydantic models for workflow nodes."""
+
+from __future__ import annotations
+
+from typing import Any
+from pydantic import BaseModel
+
+
+class NodeInput(BaseModel):
+    """Base model for node inputs."""
+
+    data: Any
+
+
+class NodeOutput(BaseModel):
+    """Base model for node outputs."""
+
+    result: Any

--- a/legal_ai_system/workflow_engine/retry.py
+++ b/legal_ai_system/workflow_engine/retry.py
@@ -1,0 +1,22 @@
+"""Retry strategies for workflow nodes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .types import RetryStrategy, WorkflowContext
+
+
+@dataclass
+class ExponentialBackoffRetry(RetryStrategy):
+    """Exponential backoff retry strategy."""
+
+    max_attempts: int = 3
+    base_delay: float = 1.0
+
+    async def should_retry(
+        self, attempt: int, exc: BaseException, context: WorkflowContext
+    ) -> float | None:
+        if attempt >= self.max_attempts:
+            return None
+        return self.base_delay * 2 ** (attempt - 1)

--- a/legal_ai_system/workflow_engine/types.py
+++ b/legal_ai_system/workflow_engine/types.py
@@ -1,0 +1,41 @@
+"""Core protocol and type definitions for the workflow engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Generic, Protocol, Sequence, TypeVar
+
+T = TypeVar("T")
+T_In = TypeVar("T_In")
+T_Out = TypeVar("T_Out")
+
+
+@dataclass
+class WorkflowContext:
+    """Context passed to workflow nodes during execution."""
+
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class RetryStrategy(Protocol):
+    """Defines retry behavior for a workflow node."""
+
+    async def should_retry(
+        self, attempt: int, exc: BaseException, context: WorkflowContext
+    ) -> float | None:
+        """Return delay before next attempt or ``None`` to stop retrying."""
+
+
+class MergeStrategy(Protocol, Generic[T]):
+    """Strategy for merging results from parallel nodes."""
+
+    async def merge(self, results: Sequence[T]) -> T:
+        """Merge a sequence of results into a single output."""
+
+
+class LegalWorkflowNode(Protocol, Generic[T_In, T_Out]):
+    """Protocol that all workflow nodes must implement."""
+
+    async def run(self, data: T_In, context: WorkflowContext) -> T_Out:
+        """Process input ``data`` and return an output."""
+


### PR DESCRIPTION
## Summary
- add new `workflow_engine` package with basic workflow builder
- implement retry and merge strategies
- provide pydantic models for validating node I/O
- export utilities via package `__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848066d4d5083239a7c43bd946b9adf