### PR TITLE
Add LegalWorkflowBuilder with merge strategies

### DIFF
--- a/legal_ai_system/tests/test_legal_workflow_builder.py
+++ b/legal_ai_system/tests/test_legal_workflow_builder.py
@@ -1,0 +1,23 @@
+import pytest
+
+from legal_ai_system.workflows import LegalWorkflowBuilder, ListMerge
+
+
+@pytest.mark.asyncio
+async def test_parallel_processing_merge_list() -> None:
+    async def node_a(x: str) -> str:
+        return x + "a"
+
+    async def node_b(x: str) -> str:
+        return x + "b"
+
+    builder = LegalWorkflowBuilder()
+
+    async def start(x: str) -> str:
+        return x
+
+    builder.add_step(start)
+    builder.add_parallel_processing([node_a, node_b], merge_strategy=ListMerge())
+
+    result = await builder.run("x")
+    assert result == ["xa", "xb"]

--- a/legal_ai_system/workflows/__init__.py
+++ b/legal_ai_system/workflows/__init__.py
@@ -1,5 +1,14 @@
 """Workflow utilities and pipeline helpers."""
 
 from .agent_workflow import AgentWorkflow
+from .legal_workflow_builder import LegalWorkflowBuilder
+from .merge import MergeStrategy, FirstResultMerge, ListMerge, DictMerge
 
-__all__ = ["AgentWorkflow"]
+__all__ = [
+    "AgentWorkflow",
+    "LegalWorkflowBuilder",
+    "MergeStrategy",
+    "FirstResultMerge",
+    "ListMerge",
+    "DictMerge",
+]

--- a/legal_ai_system/workflows/legal_workflow_builder.py
+++ b/legal_ai_system/workflows/legal_workflow_builder.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable, Iterable, List
+
+from .merge import MergeStrategy, ListMerge
+from .retry import ExponentialBackoffRetry
+
+
+class LegalWorkflowBuilder:
+    """Simple async workflow builder supporting sequential and parallel steps."""
+
+    def __init__(self) -> None:
+        self._steps: List[Callable[[Any], Awaitable[Any]]] = []
+
+    def add_step(self, step: Callable[[Any], Awaitable[Any]]) -> "LegalWorkflowBuilder":
+        """Append a sequential step to the workflow."""
+        self._steps.append(step)
+        return self
+
+    def add_parallel_processing(
+        self,
+        nodes: Iterable[Callable[[Any], Awaitable[Any]]],
+        merge_strategy: MergeStrategy | None = None,
+    ) -> "LegalWorkflowBuilder":
+        """Add a parallel processing stage.
+
+        Each node is executed concurrently and results are merged using
+        ``merge_strategy``. If a node fails, it is retried using
+        :class:`ExponentialBackoffRetry`.
+        """
+
+        strategy = merge_strategy or ListMerge()
+        node_list = list(nodes)
+        retry = ExponentialBackoffRetry()
+
+        async def parallel_step(data: Any) -> Any:
+            results = await asyncio.gather(
+                *[retry.run(node, data) for node in node_list],
+                return_exceptions=True,
+            )
+            # Propagate the first exception if all retries failed for a node
+            for res in results:
+                if isinstance(res, Exception):
+                    raise res
+            return strategy.merge(results)  # type: ignore[arg-type]
+
+        self._steps.append(parallel_step)
+        return self
+
+    async def run(self, data: Any) -> Any:
+        """Execute the workflow asynchronously."""
+        result = data
+        for step in self._steps:
+            result = await step(result)
+        return result
+
+
+__all__ = ["LegalWorkflowBuilder"]

--- a/legal_ai_system/workflows/merge.py
+++ b/legal_ai_system/workflows/merge.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List
+
+
+class MergeStrategy(ABC):
+    """Base interface for merging parallel node results."""
+
+    @abstractmethod
+    def merge(self, results: List[Any]) -> Any:
+        """Merge a list of results into a single value."""
+        raise NotImplementedError
+
+
+class FirstResultMerge(MergeStrategy):
+    """Return only the first result."""
+
+    def merge(self, results: List[Any]) -> Any:
+        return results[0] if results else None
+
+
+class ListMerge(MergeStrategy):
+    """Return all results as a list."""
+
+    def merge(self, results: List[Any]) -> List[Any]:
+        return list(results)
+
+
+class DictMerge(MergeStrategy):
+    """Merge dictionaries, later values overwrite earlier ones."""
+
+    def merge(self, results: List[Dict[str, Any]]) -> Dict[str, Any]:
+        merged: Dict[str, Any] = {}
+        for item in results:
+            merged.update(item)
+        return merged
+
+
+__all__ = [
+    "MergeStrategy",
+    "FirstResultMerge",
+    "ListMerge",
+    "DictMerge",
+]

--- a/legal_ai_system/workflows/retry.py
+++ b/legal_ai_system/workflows/retry.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable, TypeVar
+
+T = TypeVar("T")
+
+
+class ExponentialBackoffRetry:
+    """Retry helper implementing exponential backoff."""
+
+    def __init__(
+        self, max_attempts: int = 3, base_delay: float = 0.5, multiplier: float = 2.0
+    ) -> None:
+        self.max_attempts = max_attempts
+        self.base_delay = base_delay
+        self.multiplier = multiplier
+
+    async def run(self, func: Callable[[Any], Awaitable[T]], *args: Any) -> T:
+        attempt = 0
+        while True:
+            try:
+                return await func(*args)
+            except Exception:
+                attempt += 1
+                if attempt >= self.max_attempts:
+                    raise
+                delay = self.base_delay * (self.multiplier ** (attempt - 1))
+                await asyncio.sleep(delay)


### PR DESCRIPTION
## Summary
- implement `LegalWorkflowBuilder` for sequential and parallel steps
- add merge strategies (`FirstResultMerge`, `ListMerge`, `DictMerge`)
- provide exponential backoff retry helper
- expose new builder and strategies in workflow package
- test parallel processing merge logic

## Testing
- `pytest -q legal_ai_system/tests/test_legal_workflow_builder.py -o addopts=`
- `pytest -q -o addopts=` *(fails: ModuleNotFoundError: No module named 'tenacity')*

------
https://chatgpt.com/codex/tasks/task_e_684807e204708323ae1f16d3274c9042