### PR TITLE
Enable merge strategies in workflow builder

### DIFF
--- a/legal_ai_system/workflows/__init__.py
+++ b/legal_ai_system/workflows/__init__.py
@@ -2,3 +2,13 @@
 
 from .agent_workflow import AgentWorkflow
 from .legal_workflow_builder import LegalWorkflowBuilder
+from .merge import DictMerge, FirstResultMerge, ListMerge, MergeStrategy
+
+__all__ = [
+    "AgentWorkflow",
+    "LegalWorkflowBuilder",
+    "MergeStrategy",
+    "FirstResultMerge",
+    "ListMerge",
+    "DictMerge",
+]

--- a/legal_ai_system/workflows/legal_workflow_builder.py
+++ b/legal_ai_system/workflows/legal_workflow_builder.py
@@ -1,6 +1,57 @@
 from __future__ import annotations
 
+import asyncio
+from typing import Any, Awaitable, Callable, Iterable, List, Tuple
 
+from .merge import ListMerge, MergeStrategy
+from .retry import ExponentialBackoffRetry
+
+
+class LegalWorkflowBuilder:
+    """Simple async workflow builder with optional parallel steps."""
+
+    def __init__(self) -> None:
+        self._steps: List[
+            Callable[[Any], Awaitable[Any]]
+            | Tuple[List[Callable[[Any], Awaitable[Any]]], MergeStrategy]
+        ] = []
+
+    def add_step(self, func: Callable[[Any], Awaitable[Any]]) -> None:
+        """Append a sequential processing step."""
+
+        self._steps.append(func)
+
+    def add_parallel_processing(
+        self,
+        funcs: Iterable[Callable[[Any], Awaitable[Any]]],
+        *,
+        merge_strategy: MergeStrategy | None = None,
+    ) -> None:
+        """Add a parallel processing block.
+
+        Each function is executed concurrently and the results are combined
+        using ``merge_strategy``.  If no strategy is provided ``ListMerge`` is
+        used.
+        """
+
+        strategy = merge_strategy or ListMerge()
+        self._steps.append((list(funcs), strategy))
+
+    async def run(self, data: Any) -> Any:
+        """Execute the workflow returning the final result."""
+
+        retry = ExponentialBackoffRetry()
+        result = data
+        for step in self._steps:
+            if isinstance(step, tuple):
+                funcs, strategy = step
+                results = await asyncio.gather(
+                    *[retry.run(f, result) for f in funcs]
+                )
+                result = strategy.merge(list(results))
+            else:
+                result = await retry.run(step, result)
+        return result
 
 
 __all__ = ["LegalWorkflowBuilder"]


### PR DESCRIPTION
## Summary
- implement a functional `LegalWorkflowBuilder`
- expose merge strategies in workflow package
- integrate `ExponentialBackoffRetry` for node failures

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'KnowledgeGraphReasoningAgent'...)*

------
https://chatgpt.com/codex/tasks/task_e_68481235f2dc8323bc5cdadc6f0bd1ce