### PR TITLE
Add loading state hook and skeleton components

### DIFF
--- a/frontend/src/components/ProgressiveLoader.tsx
+++ b/frontend/src/components/ProgressiveLoader.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+export interface LoaderStage {
+  label: string;
+  completed: boolean;
+}
+
+interface ProgressiveLoaderProps {
+  stages: LoaderStage[];
+}
+
+const ProgressiveLoader: React.FC<ProgressiveLoaderProps> = ({ stages }) => {
+  return (
+    <div className="space-y-1">
+      {stages.map((stage, idx) => (
+        <div key={idx} className="flex items-center gap-2 text-sm">
+          <div
+            className={
+              stage.completed
+                ? 'w-3 h-3 bg-green-500 rounded-full'
+                : 'w-3 h-3 bg-gray-400 rounded-full animate-pulse'
+            }
+          />
+          <span className={stage.completed ? 'text-gray-700' : 'text-gray-500'}>
+            {stage.label}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ProgressiveLoader;

--- a/frontend/src/components/skeletons/CardSkeleton.tsx
+++ b/frontend/src/components/skeletons/CardSkeleton.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Skeleton from './Skeleton';
+
+const CardSkeleton: React.FC = () => (
+  <div className="p-4 border rounded-lg shadow bg-white space-y-3">
+    <Skeleton className="h-6 w-1/3" />
+    <Skeleton className="h-4 w-full" />
+    <Skeleton className="h-4 w-5/6" />
+  </div>
+);
+
+export default CardSkeleton;

--- a/frontend/src/components/skeletons/DashboardSkeleton.tsx
+++ b/frontend/src/components/skeletons/DashboardSkeleton.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import CardSkeleton from './CardSkeleton';
+
+const DashboardSkeleton: React.FC = () => (
+  <div className="space-y-6">
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+      {Array.from({ length: 3 }).map((_, idx) => (
+        <CardSkeleton key={idx} />
+      ))}
+    </div>
+    <CardSkeleton />
+    <CardSkeleton />
+  </div>
+);
+
+export default DashboardSkeleton;

--- a/frontend/src/components/skeletons/Skeleton.tsx
+++ b/frontend/src/components/skeletons/Skeleton.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+const Skeleton: React.FC<SkeletonProps> = ({ className = '', style, ...props }) => {
+  return (
+    <div
+      className={`bg-gray-300 rounded-md animate-pulse ${className}`.trim()}
+      style={style}
+      {...props}
+    />
+  );
+};
+
+export default Skeleton;

--- a/frontend/src/components/skeletons/TableSkeleton.tsx
+++ b/frontend/src/components/skeletons/TableSkeleton.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Skeleton from './Skeleton';
+
+interface TableSkeletonProps {
+  rows?: number;
+  columns?: number;
+}
+
+const TableSkeleton: React.FC<TableSkeletonProps> = ({ rows = 5, columns = 4 }) => {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: rows }).map((_, rowIndex) => (
+        <div key={rowIndex} className="flex gap-2">
+          {Array.from({ length: columns }).map((_, colIndex) => (
+            <Skeleton key={colIndex} className="h-6 flex-1" />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default TableSkeleton;

--- a/frontend/src/hooks/useLoadingState.ts
+++ b/frontend/src/hooks/useLoadingState.ts
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+
+export default function useLoadingState<T>() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [data, setData] = useState<T | null>(null);
+
+  const executeAsync = async (fn: () => Promise<T>): Promise<T> => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await fn();
+      setData(result);
+      return result;
+    } catch (err) {
+      setError(err as Error);
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { isLoading, error, data, executeAsync, setData };
+}

--- a/legal_ai_system/frontend/data/sample_documents.json
+++ b/legal_ai_system/frontend/data/sample_documents.json
@@ -1,0 +1,5 @@
+[
+  { "id": 1, "name": "contract_agreement.pdf", "status": "processing", "progress": 65 },
+  { "id": 2, "name": "witness_statement.docx", "status": "completed", "progress": 100 },
+  { "id": 3, "name": "evidence_photos.zip", "status": "queued", "progress": 0 }
+]

--- a/legal_ai_system/frontend/legal-ai-gui.tsx
+++ b/legal_ai_system/frontend/legal-ai-gui.tsx
@@ -6,6 +6,9 @@ import {
   BarChart, Network, Workflow, Eye, Download,
   Clock, Filter, Plus, Trash2, Edit, Save
 } from 'lucide-react';
+import TableSkeleton from '../../frontend/src/components/skeletons/TableSkeleton';
+import ProgressiveLoader, { LoaderStage } from '../../frontend/src/components/ProgressiveLoader';
+import useLoadingState from '../../frontend/src/hooks/useLoadingState';
 
 // Context for global state management
 const AppContext = createContext({});
@@ -236,11 +239,19 @@ function Dashboard() {
 // Document Processing Interface
 function DocumentProcessing() {
   const { addNotification } = useContext(AppContext);
-  const [documents, setDocuments] = useState([
-    { id: 1, name: 'contract_agreement.pdf', status: 'processing', progress: 65 },
-    { id: 2, name: 'witness_statement.docx', status: 'completed', progress: 100 },
-    { id: 3, name: 'evidence_photos.zip', status: 'queued', progress: 0 }
-  ]);
+  const { isLoading, error, data: documents, executeAsync } =
+    useLoadingState<Array<{ id: number; name: string; status: string; progress: number }>>();
+
+  useEffect(() => {
+    executeAsync(() =>
+      fetch('data/sample_documents.json').then(res => {
+        if (!res.ok) {
+          throw new Error('Failed to load documents');
+        }
+        return res.json();
+      })
+    );
+  }, []);
 
   const handleFileUpload = () => {
     addNotification('File uploaded successfully', 'success');
@@ -281,7 +292,27 @@ function DocumentProcessing() {
           <h3 className="text-lg font-semibold">Processing Queue</h3>
         </div>
         <div className="p-6 space-y-4">
-          {documents.map(doc => (
+          {isLoading && <TableSkeleton rows={3} columns={3} />}
+          {error && (
+            <div className="text-red-600 space-x-2">
+              <span>Error loading documents</span>
+              <button
+                className="underline"
+                onClick={() =>
+                  executeAsync(() =>
+                    fetch('data/sample_documents.json').then(res => {
+                      if (!res.ok) throw new Error('Failed to load documents');
+                      return res.json();
+                    })
+                  )
+                }
+              >
+                Retry
+              </button>
+            </div>
+          )}
+          {documents &&
+            documents.map(doc => (
             <div key={doc.id} className="border rounded-lg p-4">
               <div className="flex items-center justify-between mb-2">
                 <div className="flex items-center gap-3">
@@ -314,9 +345,17 @@ function DocumentProcessing() {
                     <span>{doc.progress}%</span>
                   </div>
                   <div className="w-full bg-gray-200 rounded-full h-2">
-                    <div 
+                    <div
                       className="bg-blue-600 h-2 rounded-full transition-all"
                       style={{ width: `${doc.progress}%` }}
+                    />
+                  </div>
+                  <div className="mt-2">
+                    <ProgressiveLoader
+                      stages={[
+                        { label: 'Uploaded', completed: true },
+                        { label: 'Processing', completed: doc.progress === 100 }
+                      ]}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- add generic skeleton components
- add ProgressiveLoader component
- implement useLoadingState hook
- use the new loading hook in `DocumentProcessing`
- supply sample documents data for demo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848087ef2748323b17bde2bb0d6e100