### PR TITLE
Add error boundary components

### DIFF
--- a/frontend/src/components/AsyncErrorBoundary.tsx
+++ b/frontend/src/components/AsyncErrorBoundary.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ErrorBoundary from './ErrorBoundary';
+
+export const DashboardErrorBoundary: React.FC<{children: React.ReactNode}> = ({ children }) => (
+  <ErrorBoundary level="dashboard">{children}</ErrorBoundary>
+);
+
+export const DocumentProcessingErrorBoundary: React.FC<{children: React.ReactNode}> = ({ children }) => (
+  <ErrorBoundary level="document-processing">{children}</ErrorBoundary>
+);
+
+export default ErrorBoundary;

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode | ((reset: () => void, error: Error | null) => React.ReactNode);
+  level?: string;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export default class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false, error: null };
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    this.setState({ hasError: true, error });
+    // Basic logging; replace with real logging service as needed
+    if (process.env.NODE_ENV !== 'production') {
+      console.error(`ErrorBoundary [${this.props.level ?? 'unknown'}]`, error, info);
+    }
+  }
+
+  reset = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (typeof this.props.fallback === 'function') {
+        return (this.props.fallback as any)(this.reset, this.state.error);
+      }
+      if (this.props.fallback) return this.props.fallback;
+      return (
+        <div className="p-8 text-center">
+          <h2 className="text-xl font-semibold mb-2">Something went wrong</h2>
+          {process.env.NODE_ENV !== 'production' && (
+            <pre className="text-left whitespace-pre-wrap text-sm text-red-600 mb-4">
+              {this.state.error?.message}
+            </pre>
+          )}
+          <div className="space-x-3">
+            <button onClick={this.reset} className="px-4 py-2 bg-blue-600 text-white rounded">Retry</button>
+            <a href="/" className="px-4 py-2 border rounded">Home</a>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/legal_ai_system/frontend/legal-ai-gui.tsx
+++ b/legal_ai_system/frontend/legal-ai-gui.tsx
@@ -1,11 +1,16 @@
 import React, { useState, useEffect, createContext, useContext } from 'react';
-import { 
-  Search, Upload, FileText, Users, Settings, Shield, 
+import {
+  Search, Upload, FileText, Users, Settings, Shield,
   Activity, Database, Cpu, AlertCircle, CheckCircle,
   Play, Pause, RefreshCw, ChevronRight, Home,
   BarChart, Network, Workflow, Eye, Download,
   Clock, Filter, Plus, Trash2, Edit, Save
 } from 'lucide-react';
+import ErrorBoundary from '../../frontend/src/components/ErrorBoundary';
+import {
+  DashboardErrorBoundary,
+  DocumentProcessingErrorBoundary,
+} from '../../frontend/src/components/AsyncErrorBoundary';
 
 // Context for global state management
 const AppContext = createContext({});
@@ -37,25 +42,59 @@ export default function LegalAISystem() {
   };
 
   return (
-    <AppContext.Provider value={contextValue}>
-      <div className="min-h-screen bg-gray-50">
-        <Sidebar />
-        <div className="ml-64">
-          <Header />
-          <main className="p-6">
-            <NotificationArea notifications={notifications} />
-            {currentView === 'dashboard' && <Dashboard />}
-            {currentView === 'documents' && <DocumentProcessing />}
-            {currentView === 'knowledge' && <KnowledgeGraph />}
-            {currentView === 'agents' && <AgentManagement />}
-            {currentView === 'workflows' && <WorkflowDesigner />}
-            {currentView === 'monitoring' && <Monitoring />}
-            {currentView === 'security' && <SecurityManagement />}
-            {currentView === 'settings' && <SystemSettings />}
-          </main>
+    <ErrorBoundary level="critical">
+      <AppContext.Provider value={contextValue}>
+        <div className="min-h-screen bg-gray-50">
+          <Sidebar />
+          <div className="ml-64">
+            <Header />
+            <main className="p-6">
+              <NotificationArea notifications={notifications} />
+              {currentView === 'dashboard' && (
+                <DashboardErrorBoundary>
+                  <Dashboard />
+                </DashboardErrorBoundary>
+              )}
+              {currentView === 'documents' && (
+                <DocumentProcessingErrorBoundary>
+                  <DocumentProcessing />
+                </DocumentProcessingErrorBoundary>
+              )}
+              {currentView === 'knowledge' && (
+                <ErrorBoundary level="view">
+                  <KnowledgeGraph />
+                </ErrorBoundary>
+              )}
+              {currentView === 'agents' && (
+                <ErrorBoundary level="view">
+                  <AgentManagement />
+                </ErrorBoundary>
+              )}
+              {currentView === 'workflows' && (
+                <ErrorBoundary level="view">
+                  <WorkflowDesigner />
+                </ErrorBoundary>
+              )}
+              {currentView === 'monitoring' && (
+                <ErrorBoundary level="view">
+                  <Monitoring />
+                </ErrorBoundary>
+              )}
+              {currentView === 'security' && (
+                <ErrorBoundary level="view">
+                  <SecurityManagement />
+                </ErrorBoundary>
+              )}
+              {currentView === 'settings' && (
+                <ErrorBoundary level="view">
+                  <SystemSettings />
+                </ErrorBoundary>
+              )}
+            </main>
+          </div>
         </div>
-      </div>
-    </AppContext.Provider>
+      </AppContext.Provider>
+    </ErrorBoundary>
   );
 }
 


### PR DESCRIPTION
## Summary
- introduce `ErrorBoundary` for handling React errors
- add specialized `DashboardErrorBoundary` and `DocumentProcessingErrorBoundary`
- wrap application and major views in new boundaries

## Testing
- `npx tsc --noEmit` *(fails: legal-ai-gui.tsx has pre-existing syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848150f6e1c83238006a90305f7956f