### PR TITLE
Fix README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,13 @@ python legal_ai_system/scripts/setup_environment_task.py
 ```
 ### Example: Build a Workflow
 
-
-
+```python
+# Create the default workflow and process a PDF
 workflow = builder.build()
 result = workflow.run("sample.pdf")
 print(result)
 ```
+
+You can customize the workflow builder to enable or disable specific agents.
+See the documents in the `docs/` folder for architecture details and advanced
+usage.

--- a/docs/system_layout.md
+++ b/docs/system_layout.md
@@ -111,3 +111,5 @@ Documents move through several states as they are processed:
 4. **in_review** – human review is required for some extractions.
 5. **completed** – processing finished successfully and the document is searchable.
 6. **error** – an unrecoverable issue occurred during processing.
+
+Tracking these states helps the UI report progress and highlight any processing issues.


### PR DESCRIPTION
## Summary
- fix workflow example formatting
- clarify document status lifecycle

## Testing
- `pytest -q` *(fails: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68481e1096dc8323932e21c9d752f956