### PR TITLE
Fix subprocess type error

### DIFF
--- a/legal_ai_system/scripts/install_all_dependencies.py
+++ b/legal_ai_system/scripts/install_all_dependencies.py
@@ -11,7 +11,8 @@ from typing import Iterable
 def run(cmd: Iterable[str], cwd: Path | None = None, timeout: int = 1800) -> None:
     """Run a command and raise an error if it fails."""
     print(f"Running: {' '.join(cmd)}")
-    subprocess.run(cmd, check=True, cwd=cwd, timeout=timeout)
+    # Convert to list to satisfy type checkers expecting ``Sequence[str]``
+    subprocess.run(list(cmd), check=True, cwd=cwd, timeout=timeout)
 
 
 def ensure_venv(venv_path: Path) -> None:


### PR DESCRIPTION
## Summary
- ensure subprocess.run receives a list in install_all_dependencies

## Testing
- `flake8 legal_ai_system/scripts/install_all_dependencies.py`
- `pytest` *(fails: 6 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684851c65590832380808a3c6f3caa14