### PR TITLE
Fix WorkflowDesigner import

### DIFF
--- a/legal_ai_system/frontend/legal-ai-gui.tsx
+++ b/legal_ai_system/frontend/legal-ai-gui.tsx
@@ -12,6 +12,7 @@ import {
   DashboardErrorBoundary,
   DocumentProcessingErrorBoundary,
 } from '../../frontend/src/components/AsyncErrorBoundary';
+import WorkflowDesigner from "@/components/WorkflowDesigner";
 
 
 


### PR DESCRIPTION
## Summary
- use alias import for WorkflowDesigner

## Testing
- `npm run build`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68488d534a9883238a9898772586be37