### PR TITLE
Improve error boundaries

### DIFF
--- a/frontend/src/components/AsyncErrorBoundary.tsx
+++ b/frontend/src/components/AsyncErrorBoundary.tsx
@@ -1,12 +1,46 @@
 import React from 'react';
 import ErrorBoundary from './ErrorBoundary';
 
-export const DashboardErrorBoundary: React.FC<{children: React.ReactNode}> = ({ children }) => (
-  <ErrorBoundary level="dashboard">{children}</ErrorBoundary>
+const DefaultFallback = (
+  reset: () => void,
+  error: Error | null,
+  label: string,
+) => (
+  <div className="p-8 text-center">
+    <h2 className="text-xl font-semibold mb-2">{label} Error</h2>
+    {process.env.NODE_ENV !== 'production' && error && (
+      <pre className="text-left whitespace-pre-wrap text-sm text-red-600 mb-4">
+        {error.message}
+      </pre>
+    )}
+    <div className="space-x-3">
+      <button
+        onClick={reset}
+        className="px-4 py-2 bg-blue-600 text-white rounded"
+      >
+        Retry
+      </button>
+      <a href="/" className="px-4 py-2 border rounded">Home</a>
+    </div>
+  </div>
 );
 
-export const DocumentProcessingErrorBoundary: React.FC<{children: React.ReactNode}> = ({ children }) => (
-  <ErrorBoundary level="document-processing">{children}</ErrorBoundary>
+export const DashboardErrorBoundary: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ErrorBoundary
+    level="dashboard"
+    fallback={(reset, error) => DefaultFallback(reset, error, 'Dashboard')}
+  >
+    {children}
+  </ErrorBoundary>
+);
+
+export const DocumentProcessingErrorBoundary: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ErrorBoundary
+    level="document-processing"
+    fallback={(reset, error) => DefaultFallback(reset, error, 'Document Processing')}
+  >
+    {children}
+  </ErrorBoundary>
 );
 
 export default ErrorBoundary;

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -2,8 +2,20 @@ import React from 'react';
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;
+  /**
+   * Optional fallback content to render when an error occurs. If a function is
+   * provided it will receive a reset callback and the caught error.
+   */
   fallback?: React.ReactNode | ((reset: () => void, error: Error | null) => React.ReactNode);
+  /**
+   * Optional category or severity for logging purposes.
+   */
   level?: string;
+  /**
+   * Optional callback that fires when an error is caught. This allows
+   * integration with external logging services.
+   */
+  onError?: (error: Error, info: React.ErrorInfo) => void;
 }
 
 interface ErrorBoundaryState {
@@ -17,7 +29,10 @@ export default class ErrorBoundary extends React.Component<ErrorBoundaryProps, E
   componentDidCatch(error: Error, info: React.ErrorInfo) {
     this.setState({ hasError: true, error });
     // Basic logging; replace with real logging service as needed
-    if (process.env.NODE_ENV !== 'production') {
+    if (this.props.onError) {
+      this.props.onError(error, info);
+    } else if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
       console.error(`ErrorBoundary [${this.props.level ?? 'unknown'}]`, error, info);
     }
   }


### PR DESCRIPTION
## Summary
- add onError prop to ErrorBoundary
- create more detailed fallback UIs
- provide specialized Dashboard and DocumentProcessing wrappers

## Testing
- `pytest -q` *(fails: 7 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68488d56d1cc8323b6643a5da590b658