### PR TITLE
Add fallback data_dir setting

### DIFF
--- a/legal_ai_system/scripts/main.py
+++ b/legal_ai_system/scripts/main.py
@@ -162,11 +162,19 @@ except ImportError as e:
             pass
 
     class _SettingsFallback:
-        frontend_dist_path = (
-            Path(__file__).resolve().parent.parent / "frontend" / "dist"
-        )
+        """Minimal settings fallback when core settings are unavailable."""
 
-    settings = _SettingsFallback()
+        base_dir = Path(__file__).resolve().parent.parent
+        data_dir = base_dir / "storage"
+        frontend_dist_path = base_dir / "frontend" / "dist"
+        logs_dir = base_dir / "logs"
+
+    try:
+        from legal_ai_system.core.settings import LegalAISettings
+
+        settings = LegalAISettings()
+    except Exception:  # pragma: no cover - fallback for missing dependencies
+        settings = _SettingsFallback()
 
 
 # Initialize logger for this module


### PR DESCRIPTION
## Summary
- ensure `settings.data_dir` is defined in `main.py`
- initialize full `LegalAISettings` if possible with fallback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68488d9c334c8323a2565587570489e7