### PR TITLE
Integrate design system button

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -31,6 +31,14 @@ import { Button } from '../design-system';
 <Button variant="primary" size="md">Save</Button>
 ```
 
+When referencing the design system from code outside of the `frontend/src`
+directory (for example, inside the `legal_ai_system` package), use a relative
+import path:
+
+```tsx
+import { Button } from '../../frontend/src/design-system';
+```
+
 ## Extending
 
 When building new features, prefer using these base components or create additional ones in the same folder referencing token values. This keeps styles unified and reduces duplication.

--- a/legal_ai_system/frontend/legal-ai-gui.tsx
+++ b/legal_ai_system/frontend/legal-ai-gui.tsx
@@ -12,6 +12,7 @@ import {
   DashboardErrorBoundary,
   DocumentProcessingErrorBoundary,
 } from '../../frontend/src/components/AsyncErrorBoundary';
+import { Button } from '../../frontend/src/design-system';
 
 
 
@@ -351,8 +352,10 @@ function DocumentProcessing() {
           {error && (
             <div className="text-red-600 space-x-2">
               <span>Error loading documents</span>
-              <button
-                className="underline"
+              <Button
+                variant="outline"
+                size="sm"
+                style={{ textDecoration: 'underline' }}
                 onClick={() =>
                   executeAsync(() =>
                     fetch('data/sample_documents.json').then(res => {
@@ -363,7 +366,7 @@ function DocumentProcessing() {
                 }
               >
                 Retry
-              </button>
+              </Button>
             </div>
           )}
           {documents &&


### PR DESCRIPTION
## Summary
- import Button from design system in GUI
- use Button component for retry action
- document cross-package import path for design system

## Testing
- `pytest -q` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68488d5911048323a0ee2edf80572353