### PR TITLE
Improve fallbacks and logger typing

### DIFF
--- a/legal_ai_system/api/websocket_manager.py
+++ b/legal_ai_system/api/websocket_manager.py
@@ -7,13 +7,25 @@ from typing import Any, Dict, Set
 from fastapi import WebSocket, WebSocketDisconnect
 
 try:
-    from legal_ai_system.core.detailed_logging import get_detailed_logger, LogCategory
+    from legal_ai_system.core.detailed_logging import (
+        DetailedLogger,
+        get_detailed_logger,
+        LogCategory,
+    )
 except Exception:  # pragma: no cover - fall back to std logging
     import logging
+
     class LogCategory:  # type: ignore
         API = "API"
-    def get_detailed_logger(name: str, category: LogCategory):  # type: ignore
-        return logging.getLogger(name)
+
+    class DetailedLogger(logging.Logger):
+        def __init__(self, name: str, category: LogCategory = LogCategory.API) -> None:
+            super().__init__(name)
+            self.category = category
+            self.logger = self
+
+    def get_detailed_logger(name: str, category: LogCategory) -> DetailedLogger:  # type: ignore
+        return DetailedLogger(name, category)
 
 
 class ConnectionManager:

--- a/legal_ai_system/services/realtime_publisher.py
+++ b/legal_ai_system/services/realtime_publisher.py
@@ -7,13 +7,25 @@ from typing import Optional, Dict, Any
 import psutil
 
 try:
-    from legal_ai_system.core.detailed_logging import get_detailed_logger, LogCategory
+    from legal_ai_system.core.detailed_logging import (
+        DetailedLogger,
+        get_detailed_logger,
+        LogCategory,
+    )
 except Exception:  # pragma: no cover - fallback
     import logging
+
     class LogCategory:  # type: ignore
         SYSTEM = "SYSTEM"
-    def get_detailed_logger(name: str, category: LogCategory):  # type: ignore
-        return logging.getLogger(name)
+
+    class DetailedLogger(logging.Logger):
+        def __init__(self, name: str, category: LogCategory = LogCategory.SYSTEM) -> None:
+            super().__init__(name)
+            self.category = category
+            self.logger = self
+
+    def get_detailed_logger(name: str, category: LogCategory) -> DetailedLogger:  # type: ignore
+        return DetailedLogger(name, category)
 
 from legal_ai_system.api.websocket_manager import ConnectionManager
 


### PR DESCRIPTION
## Summary
- try to load core/services classes and only define fallbacks when imports fail
- provide minimal `DetailedLogger` fallbacks
- annotate `main_api_logger` as `DetailedLogger`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684893f70a908323a2bb28c19a9d53fe