### PR TITLE
Implement workflow execution in background task

### DIFF
--- a/legal_ai_system/scripts/main.py
+++ b/legal_ai_system/scripts/main.py
@@ -1192,9 +1192,68 @@ async def process_document_background_task(  # Renamed
             "user_id": requesting_user_id,
         },
     )
+    # Initialize progress state
+    global_processing_states[document_id] = {
+        "status": "processing",
+        "progress": 0.0,
+        "stage": "starting",
+    }
+
+    async def _progress_cb(message: str, prog: float) -> None:
+        """Internal callback for workflow progress events."""
+        global_processing_states[document_id].update(
+            {"stage": message, "progress": float(prog)}
+        )
+        if websocket_manager_instance:
+            await websocket_manager_instance.broadcast_to_topic(
+                {
+                    "type": "processing_progress",
+                    "document_id": document_id,
+                    "stage": message,
+                    "progress": float(prog),
+                },
+                f"document_updates_{document_id}",
+            )
+
     try:
-        # TODO: implement actual document processing here
-        pass
+        if not service_container_instance:
+            raise RuntimeError("Service container unavailable")
+
+        orchestrator = await service_container_instance.get_service(
+            "workflow_orchestrator"
+        )
+
+        workflow = getattr(orchestrator, "workflow", None)
+        if workflow and hasattr(workflow, "register_progress_callback"):
+            workflow.register_progress_callback(_progress_cb)
+
+        global_processing_states[document_id].update(
+            {
+                "stage": "running_workflow",
+                "progress": 0.1,
+            }
+        )
+
+        await orchestrator.execute_workflow_instance(
+            document_path_str=document_file_path,
+            custom_metadata={
+                "document_id": document_id,
+                "user_id": requesting_user_id,
+                **processing_request_model.model_dump(),
+            },
+        )
+
+        global_processing_states[document_id].update(
+            {"status": "completed", "progress": 1.0, "stage": "completed"}
+        )
+        if websocket_manager_instance:
+            await websocket_manager_instance.broadcast_to_topic(
+                {
+                    "type": "processing_complete",
+                    "document_id": document_id,
+                },
+                f"document_updates_{document_id}",
+            )
     except Exception as e:
         main_api_logger.error(
             f"Background processing failed for document.",


### PR DESCRIPTION
## Summary
- use `workflow_orchestrator` when processing documents in the background
- update `global_processing_states` while running
- broadcast progress and completion events via websockets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68489af4dfec8323acd4a796b2ff6225