### PR TITLE
Add frontend API client and workflow types

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,52 @@
+// Centralized API client for backend REST endpoints
+import { WorkflowConfig, WorkflowConfigCreate, DocumentUploadResponse, ProcessingRequest, DocumentStatusResponse } from "../types/workflow";
+
+async function handleResponse<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || res.statusText);
+  }
+  return res.json() as Promise<T>;
+}
+
+export async function listWorkflows(): Promise<WorkflowConfig[]> {
+  const res = await fetch("/api/v1/workflows");
+  return handleResponse<WorkflowConfig[]>(res);
+}
+
+export async function createWorkflow(data: WorkflowConfigCreate): Promise<WorkflowConfig> {
+  const res = await fetch("/api/v1/workflows", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(data),
+  });
+  return handleResponse<WorkflowConfig>(res);
+}
+
+export async function uploadDocument(file: File): Promise<DocumentUploadResponse> {
+  const form = new FormData();
+  form.append("file", file);
+  const res = await fetch("/api/v1/documents/upload", {
+    method: "POST",
+    body: form,
+  });
+  return handleResponse<DocumentUploadResponse>(res);
+}
+
+export async function processDocument(documentId: string, request: ProcessingRequest): Promise<void> {
+  const res = await fetch(`/api/v1/documents/${documentId}/process`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(request),
+  });
+  await handleResponse(res);
+}
+
+export async function getDocumentStatus(documentId: string): Promise<DocumentStatusResponse> {
+  const res = await fetch(`/api/v1/documents/${documentId}/status`);
+  return handleResponse<DocumentStatusResponse>(res);
+}

--- a/frontend/src/components/WorkflowDesigner.tsx
+++ b/frontend/src/components/WorkflowDesigner.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from "react";
 import { Plus, Edit } from "lucide-react";
 import useLoadingState from "../hooks/useLoadingState";
 import TableSkeleton from "./skeletons/TableSkeleton";
+import { listWorkflows } from "../api/client";
+import { WorkflowConfig } from "../types/workflow";
 
 export interface WorkflowNode {
   id: string;
@@ -14,27 +16,16 @@ export interface WorkflowConnection {
   to: string;
 }
 
-export interface Workflow {
-  id: string;
-  name: string;
-  nodes: WorkflowNode[];
-  connections: WorkflowConnection[];
-}
+// Alias to maintain compatibility with earlier placeholder interface
+export type Workflow = WorkflowConfig;
 
 const WorkflowDesigner: React.FC = () => {
   const { isLoading, error, data: workflows, executeAsync } =
-    useLoadingState<Workflow[]>();
-  const [selected, setSelected] = useState<Workflow | null>(null);
+    useLoadingState<WorkflowConfig[]>();
+  const [selected, setSelected] = useState<WorkflowConfig | null>(null);
 
   useEffect(() => {
-    executeAsync(() =>
-      fetch("/api/v1/workflows").then((res) => {
-        if (!res.ok) {
-          throw new Error("Failed to load workflows");
-        }
-        return res.json();
-      })
-    );
+    executeAsync(() => listWorkflows());
   }, []);
 
   const editWorkflow = (wf: Workflow) => {
@@ -69,14 +60,7 @@ const WorkflowDesigner: React.FC = () => {
               <span>Error loading workflows</span>
               <button
                 className="underline"
-                onClick={() =>
-                  executeAsync(() =>
-                    fetch("/api/v1/workflows").then((res) => {
-                      if (!res.ok) throw new Error("Failed to load workflows");
-                      return res.json();
-                    })
-                  )
-                }
+                onClick={() => executeAsync(listWorkflows)}
               >
                 Retry
               </button>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from "./status";
+export * from "./workflow";

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -1,0 +1,36 @@
+export interface ProcessingRequest {
+  enable_ner: boolean;
+  enable_llm_extraction: boolean;
+  enable_confidence_calibration: boolean;
+  confidence_threshold: number;
+}
+
+export interface WorkflowConfig extends ProcessingRequest {
+  id: string;
+  name: string;
+  description?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WorkflowConfigCreate extends ProcessingRequest {
+  name: string;
+  description?: string | null;
+}
+
+export interface DocumentUploadResponse {
+  document_id: string;
+  filename: string;
+  size_bytes: number;
+  status: string;
+  message?: string | null;
+}
+
+export interface DocumentStatusResponse {
+  document_id: string;
+  status: string;
+  progress: number;
+  stage?: string | null;
+  estimated_completion_sec?: number | null;
+  result_summary?: Record<string, any> | null;
+}


### PR DESCRIPTION
## Summary
- add `frontend/src/api` with REST client functions
- define shared interfaces for workflows and document endpoints
- refactor `WorkflowDesigner` to use the new API client

## Testing
- `npm --prefix frontend run type-check`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68489af87974832383a37d5446633575