### PR TITLE
Document frontend build path

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ If you prefer manual installation:
    npm install
    (cd frontend && npm install)
    ```
+4. Build the frontend for production (optional when serving via FastAPI):
+   ```bash
+   (cd frontend && npm run build)
+   ```
+   This uses `vite.config.ts` which outputs to `frontend/dist`. FastAPI looks for
+   static files in `LegalAISettings.frontend_dist_path`, which defaults to the same directory,
+   so a production build will be served automatically when present.
 
 If you plan to use the optional **LexPredict** pipelines, also install `lexnlp`:
 ```bash


### PR DESCRIPTION
## Summary
- describe how to create a production build of the React frontend
- clarify that the build output is served by FastAPI from `LegalAISettings.frontend_dist_path`

## Testing
- `pytest -q` *(fails: IndentationError, ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68489b00d0048323bcefe7724f518f92