### PR TITLE
Add document update websocket hook

### DIFF
--- a/frontend/src/hooks/useDocumentUpdates.ts
+++ b/frontend/src/hooks/useDocumentUpdates.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+import useWebSocket, { subscribe, unsubscribe } from './useWebSocket';
+
+export interface DocumentUpdate {
+  document_id: number | string;
+  type: string;
+  progress?: number;
+  error?: string;
+  [key: string]: any;
+}
+
+export default function useDocumentUpdates(
+  clientId: string,
+  documentIds: Array<number | string>,
+  onUpdate: (update: DocumentUpdate) => void,
+  onAgentUpdate?: (update: any) => void,
+) {
+  const { connected, send } = useWebSocket(`/ws/${clientId}`, handleMessage);
+  const subscribed = useRef(false);
+
+  function handleMessage(data: any) {
+    if (data.type?.startsWith('processing_') || data.type === 'document_update') {
+      onUpdate(data as DocumentUpdate);
+    } else if (data.type?.startsWith('agent_') || data.type === 'agent_update') {
+      onAgentUpdate?.(data);
+    }
+  }
+
+  useEffect(() => {
+    if (connected && !subscribed.current) {
+      documentIds.forEach(id => subscribe({ send }, `document_updates_${id}`));
+      subscribe({ send }, 'agent_updates');
+      subscribed.current = true;
+    }
+    return () => {
+      if (subscribed.current) {
+        documentIds.forEach(id => unsubscribe({ send }, `document_updates_${id}`));
+        unsubscribe({ send }, 'agent_updates');
+        subscribed.current = false;
+      }
+    };
+  }, [connected, documentIds.join('|')]);
+
+  return { connected };
+}


### PR DESCRIPTION
## Summary
- implement `useDocumentUpdates` hook for subscribing to document and agent updates
- integrate websocket updates into the document processing view

## Testing
- `npm run build` *(fails: Could not resolve entry module "index.html")*
- `pytest -q` *(fails: 6 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68489afaf7488323a238a6305ef539c6