### PR TITLE
Add auth context and API token support

### DIFF
--- a/frontend/src/apiClient.ts
+++ b/frontend/src/apiClient.ts
@@ -1,0 +1,9 @@
+export default function apiFetch(input: RequestInfo | URL, init: RequestInit = {}): Promise<Response> {
+  const token = localStorage.getItem('token');
+  if (!token) {
+    return Promise.reject(new Error('No auth token'));
+  }
+  const headers = new Headers(init.headers || {});
+  headers.set('Authorization', `Bearer ${token}`);
+  return fetch(input, { ...init, headers });
+}

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import Button from '../design-system/components/Button';
+import Input from '../design-system/components/Input';
+
+const Login: React.FC = () => {
+  const { login } = useAuth();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      await login(username, password);
+    } catch {
+      setError('Invalid credentials');
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <form onSubmit={handleSubmit} className="bg-white p-6 shadow rounded space-y-4">
+        <h2 className="text-xl font-bold">Login</h2>
+        {error && <div className="text-red-600">{error}</div>}
+        <Input value={username} onChange={(e) => setUsername(e.target.value)} placeholder="Username" />
+        <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" />
+        <Button type="submit" variant="primary" className="w-full">Sign In</Button>
+      </form>
+    </div>
+  );
+};
+
+export default Login;

--- a/frontend/src/components/WorkflowDesigner.tsx
+++ b/frontend/src/components/WorkflowDesigner.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import apiFetch from "../apiClient";
 import { Plus, Edit } from "lucide-react";
 import useLoadingState from "../hooks/useLoadingState";
 import TableSkeleton from "./skeletons/TableSkeleton";
@@ -28,7 +29,7 @@ const WorkflowDesigner: React.FC = () => {
 
   useEffect(() => {
     executeAsync(() =>
-      fetch("/api/v1/workflows").then((res) => {
+      apiFetch("/api/v1/workflows").then((res) => {
         if (!res.ok) {
           throw new Error("Failed to load workflows");
         }
@@ -71,7 +72,7 @@ const WorkflowDesigner: React.FC = () => {
                 className="underline"
                 onClick={() =>
                   executeAsync(() =>
-                    fetch("/api/v1/workflows").then((res) => {
+                    apiFetch("/api/v1/workflows").then((res) => {
                       if (!res.ok) throw new Error("Failed to load workflows");
                       return res.json();
                     })

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,59 @@
+import React, { createContext, useContext, useState, useCallback } from 'react';
+
+export interface User {
+  user_id: string;
+  username: string;
+  email: string;
+  access_level: string;
+}
+
+interface AuthContextValue {
+  token: string | null;
+  user: User | null;
+  login: (u: string, p: string) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  token: null,
+  user: null,
+  login: async () => {},
+  logout: () => {},
+});
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [token, setToken] = useState<string | null>(() => localStorage.getItem('token'));
+  const [user, setUser] = useState<User | null>(() => {
+    const stored = localStorage.getItem('user');
+    return stored ? JSON.parse(stored) : null;
+  });
+
+  const login = useCallback(async (username: string, password: string) => {
+    const res = await fetch('/api/v1/auth/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    if (!res.ok) throw new Error('Login failed');
+    const data = await res.json();
+    localStorage.setItem('token', data.access_token);
+    localStorage.setItem('user', JSON.stringify(data.user));
+    setToken(data.access_token);
+    setUser(data.user);
+  }, []);
+
+  const logout = useCallback(() => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
+    setToken(null);
+    setUser(null);
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ token, user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import LegalAISystem from 'legal-ai-gui';
+import { AuthProvider } from './contexts/AuthContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
-    <LegalAISystem />
+    <AuthProvider>
+      <LegalAISystem />
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/legal_ai_system/frontend/legal-ai-gui.tsx
+++ b/legal_ai_system/frontend/legal-ai-gui.tsx
@@ -12,6 +12,8 @@ import {
   DashboardErrorBoundary,
   DocumentProcessingErrorBoundary,
 } from '../../frontend/src/components/AsyncErrorBoundary';
+import Login from '../../frontend/src/components/Login';
+import { useAuth } from '../../frontend/src/contexts/AuthContext';
 
 
 
@@ -21,6 +23,7 @@ const AppContext = createContext({});
 
 // Main App Component
 export default function LegalAISystem() {
+  const { token } = useAuth();
   const [currentView, setCurrentView] = useState('dashboard');
   const [notifications, setNotifications] = useState([]);
   const [systemStatus, setSystemStatus] = useState({
@@ -44,6 +47,10 @@ export default function LegalAISystem() {
     currentView,
     setCurrentView
   };
+
+  if (!token) {
+    return <Login />;
+  }
 
   return (
     <ErrorBoundary level="critical">
@@ -148,6 +155,7 @@ function Sidebar() {
 // Header Component
 function Header() {
   const { systemStatus } = useContext(AppContext);
+  const { logout } = useAuth();
   const healthPercentage = (systemStatus.services.healthy / systemStatus.services.total) * 100;
 
   return (
@@ -179,6 +187,7 @@ function Header() {
           <div className="flex items-center gap-2">
             <img src="/api/placeholder/32/32" alt="User" className="w-8 h-8 rounded-full" />
             <span className="text-sm font-medium">Admin User</span>
+            <Button variant="outline" size="sm" onClick={logout}>Logout</Button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- implement `AuthContext` with login and logout helpers
- add API client wrapper that injects `Authorization` header
- add `Login` page and gate main UI on token presence
- wrap app with `AuthProvider`
- secure `WorkflowDesigner` API calls

## Testing
- `npm run build`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68489b02fb908323ac485692a7c0fb53