### PR TITLE
Fix duplicate workflow registration

### DIFF
--- a/legal_ai_system/services/service_container.py
+++ b/legal_ai_system/services/service_container.py
@@ -755,7 +755,7 @@ async def create_service_container(
     await container.register_service(
         "realtime_analysis_workflow",
         factory=lambda sc: RealTimeAnalysisWorkflow(
-            sc, config=WorkflowConfig(**sc.get_active_workflow_config())
+            sc, workflow_config=WorkflowConfig(**sc.get_active_workflow_config())
         ),
         is_async_factory=False,
     )
@@ -868,17 +868,6 @@ async def create_service_container(
         "workflow_orchestrator",
         factory=lambda sc, topic=workflow_topic: WorkflowOrchestrator(
             sc, topic=topic
-        ),
-        is_async_factory=False,
-    )
-
-    # Register workflow with active configuration
-    workflow_conf_dict = config_manager_service.get("workflow_config", {})
-    container.update_workflow_config(workflow_conf_dict)
-    await container.register_service(
-        "realtime_analysis_workflow",
-        factory=lambda sc: RealTimeAnalysisWorkflow(
-            sc, **asdict(sc.get_active_workflow_config())
         ),
         is_async_factory=False,
     )

--- a/legal_ai_system/tests/test_service_container_order.py
+++ b/legal_ai_system/tests/test_service_container_order.py
@@ -1,0 +1,33 @@
+import asyncio
+import pytest
+
+from legal_ai_system.services.service_container import ServiceContainer
+
+class DummyA:
+    def __init__(self):
+        self.initialized = False
+
+    async def initialize_service(self):
+        await asyncio.sleep(0)
+        self.initialized = True
+
+class DummyB:
+    def __init__(self):
+        self.initialized = False
+
+    async def initialize_service(self):
+        await asyncio.sleep(0)
+        self.initialized = True
+
+@pytest.mark.asyncio
+async def test_initialization_order():
+    container = ServiceContainer()
+
+    await container.register_service("a", factory=lambda sc: DummyA())
+    await container.register_service("b", factory=lambda sc: DummyB())
+
+    await container.initialize_all_services()
+
+    assert container._initialization_order == ["a", "b"]
+    assert container._service_states["a"].name == "INITIALIZED"
+    assert container._service_states["b"].name == "INITIALIZED"


### PR DESCRIPTION
## Summary
- fix workflow registration with correct `workflow_config`
- remove redundant workflow registration block
- test service initialization order

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68489d9f1d0c8323a00d302adef0b815