### PR TITLE
Fix workflow config handling

### DIFF
--- a/legal_ai_system/scripts/main.py
+++ b/legal_ai_system/scripts/main.py
@@ -890,7 +890,7 @@ async def process_document_rest(  # Renamed
     user_id_for_task = "mock_user_for_processing"  # Placeholder if auth is off
 
     if service_container_instance:
-        service_container_instance.update_workflow_config(
+        await service_container_instance.update_workflow_config(
             processing_request.model_dump()
         )
     background_tasks.add_task(

--- a/legal_ai_system/services/service_container.py
+++ b/legal_ai_system/services/service_container.py
@@ -8,7 +8,7 @@ core services and agents within the Legal AI System.
 
 import asyncio
 from typing import Dict, Any, Optional, Callable, Awaitable, List, TYPE_CHECKING
-from dataclasses import asdict
+
 from enum import Enum
 from datetime import datetime, timezone
 import os
@@ -129,6 +129,8 @@ class ServiceContainer:
         self._lock = (
             asyncio.Lock()
         )  # For thread-safe registration and retrieval if needed (though primarily async)
+        # Active workflow configuration shared across workflow instances
+        self._active_workflow_config: Dict[str, Any] = {}
 
         service_container_logger.info("ServiceContainer instance created.")
 
@@ -462,18 +464,6 @@ class ServiceContainer:
             parameters={"task_name": getattr(coro, "__name__", "unnamed_coro")},
         )
 
-    def get_active_workflow_config(self) -> WorkflowConfig:
-        """Return the currently active workflow configuration."""
-        return self._active_workflow_config
-
-    def update_workflow_config(self, new_config: Dict[str, Any]) -> None:
-        """Update the workflow configuration and propagate to the workflow instance."""
-        for key, value in new_config.items():
-            setattr(self._active_workflow_config, key, value)
-        if "realtime_analysis_workflow" in self._services:
-            workflow = self._services["realtime_analysis_workflow"]
-            if hasattr(workflow, "update_config"):
-                workflow.update_config(**new_config)
 
 
 # Global factory function to create and populate the service container
@@ -874,11 +864,11 @@ async def create_service_container(
 
     # Register workflow with active configuration
     workflow_conf_dict = config_manager_service.get("workflow_config", {})
-    container.update_workflow_config(workflow_conf_dict)
+    await container.update_workflow_config(workflow_conf_dict)
     await container.register_service(
         "realtime_analysis_workflow",
         factory=lambda sc: RealTimeAnalysisWorkflow(
-            sc, **asdict(sc.get_active_workflow_config())
+            sc, **sc.get_active_workflow_config()
         ),
         is_async_factory=False,
     )


### PR DESCRIPTION
## Summary
- remove duplicate workflow config methods
- use async workflow config updates consistently
- adjust service container to store workflow config
- await workflow config update in API

## Testing
- `pytest -q` *(fails: couldn't parse some files)*

------
https://chatgpt.com/codex/tasks/task_e_68489d9df46c83239872964439b43348