### PR TITLE
Add linkage check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ tual environment and run the tests:
 ```bash
 python legal_ai_system/scripts/setup_environment_task.py
 ```
+
+### Start Task
+
+After installing the dependencies you can run a quick linkage verification and
+the full test suite with:
+
+```bash
+python scripts/start_linkage_check.py
+```
 ### Example: Build a Workflow
 
 ```python

--- a/scripts/start_linkage_check.py
+++ b/scripts/start_linkage_check.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Run system health checks and the test suite."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run(cmd: list[str]) -> None:
+    """Execute a command and fail if it errors."""
+    print(f"Running: {' '.join(cmd)}")
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    python_exe = sys.executable
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    try:
+        from legal_ai_system.services.system_initializer import test_system_health
+
+        health = test_system_health()
+        print("System health summary:")
+        for key, value in health.items():
+            print(f"  {key}: {value}")
+    except Exception as exc:  # pragma: no cover - best effort
+        print(f"Health check failed: {exc}")
+
+    run([python_exe, "-m", "pytest", str(repo_root / "legal_ai_system" / "tests")])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add scripts/start_linkage_check.py for running system health checks and tests
- document "Start Task" instructions in README

## Testing
- `python scripts/start_linkage_check.py` *(fails: 6 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68489da369708323afb7dac808d9d60b