### PR TITLE
Remove duplicate workflow config methods

### DIFF
--- a/legal_ai_system/scripts/main.py
+++ b/legal_ai_system/scripts/main.py
@@ -890,7 +890,7 @@ async def process_document_rest(  # Renamed
     user_id_for_task = "mock_user_for_processing"  # Placeholder if auth is off
 
     if service_container_instance:
-        service_container_instance.update_workflow_config(
+        await service_container_instance.update_workflow_config(
             processing_request.model_dump()
         )
     background_tasks.add_task(


### PR DESCRIPTION
## Summary
- remove duplicate workflow configuration helpers
- adjust service container setup to await workflow config updates
- await workflow config update in API handler

## Testing
- `pytest -q` *(fails: 6 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68489dc3ec2c8323abb9fff0882c28aa