### PR TITLE
Document integration plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,6 @@ print(result)
 
 You can customize the workflow builder to enable or disable specific agents.
 See the documents in the `docs/` folder for architecture details and advanced
-usage.
+usage. The [Integration Guide](docs/integration_plan.md) summarises the
+five-phase integration plan, WebSocket patterns and deployment tips and
+includes sections on security, testing, success metrics and troubleshooting.


### PR DESCRIPTION
## Summary
- mention integration plan docs in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6848a61c83c48323a7f25074e4ce18c1