### PR TITLE
Add run_tests script and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ tual environment and run the tests:
 python legal_ai_system/scripts/setup_environment_task.py
 ```
 
+For a quick test run you can also execute:
+
+```bash
+./scripts/run_tests.sh
+```
+
+The script creates a `.venv`, installs development dependencies, and runs
+`pytest`.
+
 ### Start Task
 
 

--- a/docs/test_setup.md
+++ b/docs/test_setup.md
@@ -24,4 +24,13 @@ pip install -e .[dev]
 pytest
 ```
 
-The command above sets up a virtual environment, installs dependencies, and executes the test suite.
+The commands above create a virtual environment, install all development
+dependencies, and execute the test suite. To automate these steps, you can run
+the helper script:
+
+```bash
+./scripts/run_tests.sh
+```
+
+`run_tests.sh` ensures `.venv` exists, installs the required packages, and then
+invokes `pytest`.

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Simple helper to create a virtual environment, install dev dependencies,
+# and execute the pytest suite.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_PATH="$REPO_ROOT/.venv"
+
+if [ ! -d "$VENV_PATH" ]; then
+  python3 -m venv "$VENV_PATH"
+fi
+
+source "$VENV_PATH/bin/activate"
+cd "$REPO_ROOT"
+
+pip install --upgrade pip
+pip install -r requirements.txt
+pip install -e .[dev]
+
+pytest "$@"


### PR DESCRIPTION
## Summary
- add a helper script `scripts/run_tests.sh` that creates a virtual environment, installs dev dependencies and runs pytest
- reference the helper script in `docs/test_setup.md`
- reference the helper script in `README.md`

## Testing
- `./scripts/run_tests.sh` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_6848a4d8a06883239f211a0ef381f1df