### PR TITLE
Update test docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ tual environment and run the tests:
 python legal_ai_system/scripts/setup_environment_task.py
 ```
 
+## Running Tests
+
+Install the development dependencies before executing the test suite. Run
+`pip install -e .[dev]` or use the installation script above. Missing packages
+such as `pytest-mock` will cause test failures.
+
+```bash
+pytest
+```
+
 ### Start Task
 
 

--- a/docs/test_setup.md
+++ b/docs/test_setup.md
@@ -14,7 +14,13 @@ The core dependencies for running the tests are listed below. They can be instal
 
 Additional packages from `requirements.txt` are needed for the application itself (FastAPI, pydantic, etc.).
 
+Running the tests without these dependencies will result in import errors. For
+example, missing `pytest-mock` will cause fixture failures.
+
 ## Running the Tests
+
+Ensure the development dependencies are installed before executing `pytest`. Run
+`pip install -e .[dev]` or use `python legal_ai_system/scripts/install_all_dependencies.py`.
 
 ```bash
 python3 -m venv .venv


### PR DESCRIPTION
## Summary
- mention running the dev install step prior to pytest
- call out missing packages like pytest-mock in test setup docs

## Testing
- `pytest -q` *(fails: 4 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6848a4da0dd48323b0e851c31315054b