### PR TITLE
Add onboarding guide and diagrams

### DIFF
--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -1,0 +1,61 @@
+# Developer Onboarding Guide
+
+Welcome to the Legal AI System project! This guide helps new contributors set up
+ their environment and explains the typical development workflow.
+
+## Prerequisites
+- Python 3.9 or later
+- Node.js 18+
+- Git
+
+## Environment Setup
+1. **Clone the repository**
+   ```bash
+   git clone <repository-url>
+   cd Legal-AI-ssistant
+   ```
+2. **Create and activate a virtual environment**
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   ```
+3. **Install dependencies**
+   You can install everything with the convenience script:
+   ```bash
+   python legal_ai_system/scripts/install_all_dependencies.py
+   ```
+   This script installs Python packages and Node packages for the React frontend.
+   If you prefer manual installation run:
+   ```bash
+   pip install -r requirements.txt
+   npm install
+   (cd frontend && npm install)
+   ```
+4. **Optional extras**
+   Additional libraries for audio transcription and advanced parsing are listed in
+   [ENV_SETUP.md](../ENV_SETUP.md). Install them as needed.
+
+## Running Tests
+Tests use **pytest**. After installing the `dev` dependencies:
+```bash
+pip install -e .[dev]
+pytest
+```
+See [docs/test_setup.md](test_setup.md) for details.
+
+## Development Workflow
+1. Create a feature branch and make changes.
+2. Ensure code conforms to formatting rules:
+   ```bash
+   black .
+   isort .
+   ```
+3. Run `pytest` to verify that all tests pass.
+4. Commit your work and open a pull request.
+
+## Additional Resources
+- [System Layout](system_layout.md) – overview of services and agents
+- [API Endpoints](api_endpoints.md) – REST API documentation
+- [Integration Guide](integration_plan.md) – deployment and WebSocket usage
+
+Happy coding!

--- a/docs/diagrams/realtime_analysis_workflow_sequence.md
+++ b/docs/diagrams/realtime_analysis_workflow_sequence.md
@@ -1,0 +1,27 @@
+# RealTimeAnalysisWorkflow Execution Sequence
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Integration as IntegrationService
+    participant Workflow as RealTimeAnalysisWorkflow
+    participant Processor as DocumentProcessorAgent
+    participant Rewriter as DocumentRewriterAgent
+    participant Ontology as OntologyExtractionAgent
+    participant Graph as RealTimeGraphManager
+    participant Memory as ReviewableMemory
+
+    User->>Integration: handle_document_upload(doc)
+    Integration->>Workflow: run(doc)
+    Workflow->>Processor: extract text
+    Processor-->>Workflow: content
+    Workflow->>Rewriter: clean text
+    Rewriter-->>Workflow: cleaned
+    Workflow->>Ontology: extract entities
+    Ontology-->>Workflow: entities
+    Workflow->>Graph: update graph
+    Graph-->>Workflow: confirmed
+    Workflow->>Memory: store results
+    Memory-->>Workflow: stored
+    Integration<<--Workflow: return summary
+```

--- a/docs/diagrams/service_container_initialization.md
+++ b/docs/diagrams/service_container_initialization.md
@@ -1,0 +1,36 @@
+# ServiceContainer Initialization Sequence
+
+```mermaid
+sequenceDiagram
+    participant App as Application
+    participant Container as ServiceContainer
+    participant Config as ConfigurationManager
+    participant Persistence as PersistenceManager
+    participant Security as SecurityManager
+    participant LLM as LLMManager
+    participant Embed as EmbeddingManager
+    participant Graph as KnowledgeGraphManager
+    participant Vector as VectorStore
+    participant RTGraph as RealTimeGraphManager
+    participant Memory as UnifiedMemoryManager
+    participant Review as ReviewableMemory
+    participant Violations as ViolationReviewDB
+    participant Workflow as RealTimeAnalysisWorkflow
+    participant Orchestrator as WorkflowOrchestrator
+
+    App->>Container: create_service_container()
+    Container->>Config: create
+    Container->>Persistence: create
+    Container->>Security: create
+    Container->>LLM: create
+    Container->>Embed: create
+    Container->>Graph: create
+    Container->>Vector: create
+    Container->>RTGraph: create
+    Container->>Memory: create
+    Container->>Review: create
+    Container->>Violations: create
+    Container->>Workflow: create
+    Container->>Orchestrator: create
+    Container-->>App: initialized
+```

--- a/docs/system_layout.md
+++ b/docs/system_layout.md
@@ -2,6 +2,12 @@
 
 This document summarizes the major agents and services within the **Legal AI System** and how they interact.  The architecture centers on a dependency injection container that wires together agents, managers, and workflows.  Each component registers itself with the container so that initialization order, configuration, and shutdown are handled consistently.
 
+Visual overviews of the initialization and workflow steps are available in the
+[ServiceContainer initialization diagram](diagrams/service_container_initialization.md)
+and the [RealTimeAnalysisWorkflow sequence diagram](diagrams/realtime_analysis_workflow_sequence.md).
+For details on REST endpoints, see the [API reference](api_endpoints.md) and the
+[Integration Guide](integration_plan.md).
+
 ## Core Architecture
 
 - **ServiceContainer** – manages creation, initialization and shutdown of all services and agents.  It provides dependency injection throughout the system.  Source: `services/service_container.py` lines 1‑6 show its purpose.  The container registers factories for each component, initializes them asynchronously, and exposes lifecycle hooks so resources are cleaned up at shutdown.


### PR DESCRIPTION
## Summary
- create developer onboarding guide with environment setup and workflow tips
- add ServiceContainer initialization and RealTimeAnalysisWorkflow diagrams
- reference diagrams and API docs from system layout

## Testing
- `pytest -q` *(fails: 4 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6848a528f5d883239520bed07a5db287