### PR TITLE
Implement routing workflow with document classification

### DIFF
--- a/legal_ai_system/tests/test_advanced_routing_workflow.py
+++ b/legal_ai_system/tests/test_advanced_routing_workflow.py
@@ -1,0 +1,33 @@
+import sys
+from types import ModuleType
+
+# Stub heavy optional dependencies
+for name in ["fitz", "pytesseract", "PIL", "PIL.Image"]:
+    sys.modules.setdefault(name, ModuleType(name))
+
+import pytest
+from legal_ai_system.workflows.routing import (
+    build_advanced_legal_workflow,
+    DocumentClassificationNode,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "classification,path_keyword",
+    [
+        ({"primary_type": "contract"}, "Contract summary"),
+        ({"primary_type": "court_filing"}, "Litigation summary"),
+        ({"primary_type": "statute"}, "Regulatory summary"),
+        ({"primary_type": "other"}, "Evidence summary"),
+    ],
+)
+async def test_routing(monkeypatch, classification, path_keyword):
+    def fake_classify(self, text):
+        return classification
+
+    monkeypatch.setattr(DocumentClassificationNode, "__call__", fake_classify)
+
+    wf = build_advanced_legal_workflow()
+    result = await wf.run("doc")
+    assert path_keyword in result

--- a/legal_ai_system/workflows/__init__.py
+++ b/legal_ai_system/workflows/__init__.py
@@ -2,6 +2,7 @@
 
 from .agent_workflow import AgentWorkflow
 from .legal_workflow_builder import LegalWorkflowBuilder
+from .routing import build_advanced_legal_workflow
 from ..workflow_engine.merge import (
     MergeStrategy,
     ConcatMerge,
@@ -9,12 +10,11 @@ from ..workflow_engine.merge import (
     DictUpdateMerge,
 )
 
-
 __all__ = [
     "AgentWorkflow",
     "LegalWorkflowBuilder",
+    "build_advanced_legal_workflow",
     "MergeStrategy",
     "ConcatMerge",
     "ListMerge",
-
 ]

--- a/legal_ai_system/workflows/routing/__init__.py
+++ b/legal_ai_system/workflows/routing/__init__.py
@@ -1,0 +1,19 @@
+"""Routing workflow components for advanced legal analysis."""
+
+from .document_classification_node import DocumentClassificationNode
+from .analysis_paths import (
+    ContractAnalysisPath,
+    LitigationAnalysisPath,
+    RegulatoryAnalysisPath,
+    EvidenceAnalysisPath,
+)
+from .advanced_workflow import build_advanced_legal_workflow
+
+__all__ = [
+    "DocumentClassificationNode",
+    "ContractAnalysisPath",
+    "LitigationAnalysisPath",
+    "RegulatoryAnalysisPath",
+    "EvidenceAnalysisPath",
+    "build_advanced_legal_workflow",
+]

--- a/legal_ai_system/workflows/routing/advanced_workflow.py
+++ b/legal_ai_system/workflows/routing/advanced_workflow.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from ...utils.workflow_builder import WorkflowBuilder
+
+from .document_classification_node import DocumentClassificationNode
+from .analysis_paths import (
+    ContractAnalysisPath,
+    LitigationAnalysisPath,
+    RegulatoryAnalysisPath,
+    EvidenceAnalysisPath,
+)
+
+
+def add_conditional_edges(
+    builder: WorkflowBuilder, start: str, mapping: dict[str, callable]
+) -> None:
+    """Helper to add multiple conditional edges from ``start``."""
+    for target, condition in mapping.items():
+        builder.add_edge(start, target, condition=condition)
+
+
+def build_advanced_legal_workflow() -> WorkflowBuilder:
+    """Create a workflow that routes documents based on classification."""
+    builder = WorkflowBuilder()
+
+    classifier_node = DocumentClassificationNode()
+
+    async def classify_document(text: str):
+        return classifier_node(text)
+
+    builder.register_node("classify_document", classify_document)
+    builder.set_entry_point("classify_document")
+
+    contract_path = ContractAnalysisPath()
+    litigation_path = LitigationAnalysisPath()
+    regulatory_path = RegulatoryAnalysisPath()
+    evidence_path = EvidenceAnalysisPath()
+
+    contract_path.build(builder)
+    litigation_path.build(builder)
+    regulatory_path.build(builder)
+    evidence_path.build(builder)
+
+    add_conditional_edges(
+        builder,
+        "classify_document",
+        {
+            ContractAnalysisPath.ENTRY_NODE: lambda r: isinstance(r, dict) and r.get("primary_type") == "contract",
+            LitigationAnalysisPath.ENTRY_NODE: lambda r: isinstance(r, dict) and r.get("primary_type") == "court_filing",
+            RegulatoryAnalysisPath.ENTRY_NODE: lambda r: isinstance(r, dict) and r.get("primary_type") == "statute",
+            EvidenceAnalysisPath.ENTRY_NODE: lambda r: isinstance(r, dict) and r.get("primary_type") not in {"contract", "court_filing", "statute"},
+        },
+    )
+
+    return builder
+
+
+__all__ = ["build_advanced_legal_workflow", "add_conditional_edges"]

--- a/legal_ai_system/workflows/routing/analysis_paths.py
+++ b/legal_ai_system/workflows/routing/analysis_paths.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from ...utils.workflow_builder import WorkflowBuilder
+
+
+class ContractAnalysisPath:
+    """Subgraph for contract-specific analysis."""
+
+    ENTRY_NODE = "contract_analysis"
+
+    def build(self, builder: WorkflowBuilder) -> None:
+        async def contract_analysis(text: str) -> str:
+            return f"Contract analysis of {text}"
+
+        async def contract_summary(text: str) -> str:
+            return f"Contract summary: {text}"
+
+        builder.register_node(self.ENTRY_NODE, contract_analysis)
+        builder.register_node("contract_summary", contract_summary)
+        builder.add_edge(self.ENTRY_NODE, "contract_summary")
+
+
+class LitigationAnalysisPath:
+    """Subgraph for litigation-related documents."""
+
+    ENTRY_NODE = "litigation_analysis"
+
+    def build(self, builder: WorkflowBuilder) -> None:
+        async def litigation_analysis(text: str) -> str:
+            return f"Litigation analysis of {text}"
+
+        async def litigation_summary(text: str) -> str:
+            return f"Litigation summary: {text}"
+
+        builder.register_node(self.ENTRY_NODE, litigation_analysis)
+        builder.register_node("litigation_summary", litigation_summary)
+        builder.add_edge(self.ENTRY_NODE, "litigation_summary")
+
+
+class RegulatoryAnalysisPath:
+    """Subgraph for statutory or regulatory documents."""
+
+    ENTRY_NODE = "regulatory_analysis"
+
+    def build(self, builder: WorkflowBuilder) -> None:
+        async def regulatory_analysis(text: str) -> str:
+            return f"Regulatory analysis of {text}"
+
+        async def regulatory_summary(text: str) -> str:
+            return f"Regulatory summary: {text}"
+
+        builder.register_node(self.ENTRY_NODE, regulatory_analysis)
+        builder.register_node("regulatory_summary", regulatory_summary)
+        builder.add_edge(self.ENTRY_NODE, "regulatory_summary")
+
+
+class EvidenceAnalysisPath:
+    """Fallback path for miscellaneous evidence documents."""
+
+    ENTRY_NODE = "evidence_analysis"
+
+    def build(self, builder: WorkflowBuilder) -> None:
+        async def evidence_analysis(text: str) -> str:
+            return f"Evidence analysis of {text}"
+
+        async def evidence_summary(text: str) -> str:
+            return f"Evidence summary: {text}"
+
+        builder.register_node(self.ENTRY_NODE, evidence_analysis)
+        builder.register_node("evidence_summary", evidence_summary)
+        builder.add_edge(self.ENTRY_NODE, "evidence_summary")
+
+
+__all__ = [
+    "ContractAnalysisPath",
+    "LitigationAnalysisPath",
+    "RegulatoryAnalysisPath",
+    "EvidenceAnalysisPath",
+]

--- a/legal_ai_system/workflows/routing/document_classification_node.py
+++ b/legal_ai_system/workflows/routing/document_classification_node.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+try:  # pragma: no cover - optional dependency
+    from langgraph.graph import BaseNode
+except Exception:  # pragma: no cover - fallback when langgraph isn't installed
+    class BaseNode:
+        """Minimal stand-in for :class:`langgraph.graph.BaseNode`."""
+
+        pass
+
+from ...utils.document_utils import LegalDocumentClassifier
+
+
+class DocumentClassificationNode(BaseNode):
+    """Classify document text using :class:`LegalDocumentClassifier`."""
+
+    def __init__(self, classifier: LegalDocumentClassifier | None = None) -> None:
+        self.classifier = classifier or LegalDocumentClassifier()
+
+    def __call__(self, text: str) -> Dict[str, Any]:
+        """Return classification details for ``text``."""
+        return self.classifier.classify(text)
+
+
+__all__ = ["DocumentClassificationNode"]


### PR DESCRIPTION
## Summary
- add `DocumentClassificationNode` for classifying input text
- implement analysis path subgraphs for contract, litigation, regulatory, and evidence workflows
- create `build_advanced_legal_workflow` with conditional routing based on classification
- expose new workflow builder in `workflows` package
- test that classification results route documents to the correct analysis path

## Testing
- `pytest legal_ai_system/tests/test_advanced_routing_workflow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a672aeb48323ae81761fcfc4b684