### PR TITLE
Refactor persistence pool usage

### DIFF
--- a/legal_ai_system/core/enhanced_vector_store.py
+++ b/legal_ai_system/core/enhanced_vector_store.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from queue import Queue
+from .enhanced_persistence import ConnectionPool
 
 # Import detailed logging system
 from .detailed_logging import (
@@ -290,9 +291,12 @@ class EnhancedVectorStore:
         enable_gpu: bool = False,
         document_index_path: str | None = None,
         entity_index_path: str | None = None,
+        connection_pool: Optional[ConnectionPool] = None,
     ):
         """Initialize enhanced vector store with comprehensive configuration"""
         vector_logger.info("=== INITIALIZING ENHANCED VECTOR STORE ===")
+
+        self.connection_pool = connection_pool
         
         self.storage_path = Path(storage_path)
         self.storage_path.mkdir(parents=True, exist_ok=True)
@@ -917,12 +921,12 @@ class EnhancedVectorStore:
 
 
 def create_enhanced_vector_store(
-    service_container: Any,
-    service_config: Optional[Dict[str, Any]] | None = None,
+    connection_pool: ConnectionPool,
+    config: Optional[Dict[str, Any]] | None = None,
 ) -> "EnhancedVectorStore":
     """Factory function used by :class:`ServiceContainer`."""
 
-    cfg = service_config or {}
+    cfg = config or {}
     return EnhancedVectorStore(
         storage_path=cfg.get("STORAGE_PATH", "./storage/vectors"),
         embedding_model=cfg.get("embedding_model_name", "sentence-transformers/all-MiniLM-L6-v2"),
@@ -930,6 +934,7 @@ def create_enhanced_vector_store(
         enable_gpu=cfg.get("ENABLE_GPU_FAISS", False),
         document_index_path=cfg.get("DOCUMENT_INDEX_PATH"),
         entity_index_path=cfg.get("ENTITY_INDEX_PATH"),
+        connection_pool=connection_pool,
     )
 
     # ------------------------------------------------------------------

--- a/legal_ai_system/core/vector_store_manager.py
+++ b/legal_ai_system/core/vector_store_manager.py
@@ -24,7 +24,10 @@ class VectorStoreManager:
     async def initialize(self, service_container: Optional[Any] = None) -> None:
         """Initialize the underlying vector store if needed."""
         if self.store is None and create_vector_store is not None:
-            self.store = create_vector_store(service_container or {})
+            pool = None
+            if service_container and hasattr(service_container, "get_service"):
+                pool = await service_container.get_service("connection_pool")
+            self.store = create_vector_store(pool, service_container or {})
         if self.store and hasattr(self.store, "initialize") and not self._initialized:
             await self.store.initialize()
             self._initialized = True

--- a/legal_ai_system/services/knowledge_graph_manager.py
+++ b/legal_ai_system/services/knowledge_graph_manager.py
@@ -18,6 +18,7 @@ import hashlib
 
 # Import detailed logging
 from ..core.detailed_logging import get_detailed_logger, LogCategory, detailed_log_function
+from ..core.enhanced_persistence import ConnectionPool
 
 # Initialize loggers
 kg_logger = get_detailed_logger("Knowledge_Graph_Manager", LogCategory.KNOWLEDGE_GRAPH)
@@ -121,7 +122,12 @@ class KnowledgeGraphManager:
     """
     
     @detailed_log_function(LogCategory.KNOWLEDGE_GRAPH)
-    def __init__(self, storage_dir: str = "./storage/knowledge_graph", service_config: Optional[Dict[str, Any]] = None):
+    def __init__(
+        self,
+        storage_dir: str = "./storage/knowledge_graph",
+        service_config: Optional[Dict[str, Any]] = None,
+        connection_pool: Optional[ConnectionPool] = None,
+    ):
         """Initialize knowledge graph manager."""
         kg_logger.info("=== INITIALIZING KNOWLEDGE GRAPH MANAGER ===")
         
@@ -129,6 +135,7 @@ class KnowledgeGraphManager:
         self.storage_dir.mkdir(parents=True, exist_ok=True)
         
         self.config = service_config or {}
+        self.connection_pool = connection_pool
         
         # Storage components
         self.entities: Dict[str, Entity] = {}
@@ -629,6 +636,11 @@ class KnowledgeGraphManager:
         return health
 
 # Service container factory function
-def create_knowledge_graph_manager(config: Optional[Dict[str, Any]] = None) -> KnowledgeGraphManager:
+def create_knowledge_graph_manager(
+    connection_pool: ConnectionPool,
+    config: Optional[Dict[str, Any]] = None,
+) -> KnowledgeGraphManager:
     """Factory function for service container integration."""
-    return KnowledgeGraphManager(service_config=config or {})
+    return KnowledgeGraphManager(
+        service_config=config or {}, connection_pool=connection_pool
+    )


### PR DESCRIPTION
## Summary
- initialize shared `ConnectionPool` in service container
- inject pool into `EnhancedPersistenceManager`, `KnowledgeGraphManager`, and `EnhancedVectorStore`
- use pool in `VectorStoreManager`
- close services properly on shutdown

## Testing
- `python -m py_compile legal_ai_system/core/enhanced_persistence.py legal_ai_system/core/enhanced_vector_store.py legal_ai_system/core/vector_store_manager.py legal_ai_system/services/knowledge_graph_manager.py legal_ai_system/services/service_container.py`
- `pytest -k nothing -q` *(fails: ImportError and SyntaxError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6848af3c0bf48323b79b6be55b3c089b