### PR TITLE
Add TF-IDF keyword extractor

### DIFF
--- a/legal_ai_system/analytics/__init__.py
+++ b/legal_ai_system/analytics/__init__.py
@@ -1,0 +1,5 @@
+"""Analytics helpers for text processing and modeling."""
+
+from .keyword_extractor import extract_keywords
+
+__all__ = ["extract_keywords"]

--- a/legal_ai_system/analytics/keyword_extractor.py
+++ b/legal_ai_system/analytics/keyword_extractor.py
@@ -1,0 +1,33 @@
+"""Keyword extraction utilities."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from sklearn.feature_extraction.text import TfidfVectorizer
+
+
+def extract_keywords(text: str, top_k: int = 5) -> List[Tuple[str, float]]:
+    """Return the top *top_k* keywords ranked by TF-IDF score.
+
+    Parameters
+    ----------
+    text: str
+        Input document text.
+    top_k: int
+        Number of keywords to return.
+
+    Returns
+    -------
+    List[Tuple[str, float]]
+        Keyword-score pairs sorted in descending order.
+    """
+    if not text.strip() or top_k <= 0:
+        return []
+
+    vectorizer = TfidfVectorizer(stop_words="english")
+    tfidf_matrix = vectorizer.fit_transform([text])
+    scores = tfidf_matrix.toarray()[0]
+    features = vectorizer.get_feature_names_out()
+    ranked = sorted(zip(features, scores), key=lambda x: x[1], reverse=True)
+    return ranked[:top_k]

--- a/legal_ai_system/tests/test_keyword_extractor.py
+++ b/legal_ai_system/tests/test_keyword_extractor.py
@@ -1,0 +1,21 @@
+import pytest
+
+from legal_ai_system.analytics.keyword_extractor import extract_keywords
+
+
+@pytest.mark.unit
+def test_extract_keywords_ranks_terms():
+    text = (
+        "Contract law governs contracts, agreements and obligations. "
+        "A contract is a legally binding agreement. "
+        "In contract law, the agreement is enforceable."
+    )
+    keywords = extract_keywords(text, top_k=3)
+    assert len(keywords) == 3
+    assert keywords[0][0] == "contract"
+    assert any(k == "agreement" for k, _ in keywords)
+
+
+@pytest.mark.unit
+def test_extract_keywords_empty_text_returns_empty_list():
+    assert extract_keywords("", top_k=5) == []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ tqdm = "^4.65.0"
 pathlib = "^1.0.1"
 typing-extensions = "^4.7.0"
 pyspellchecker = "^0.7.2"
+scikit-learn = "^1.3.0"
 
 [tool.poetry.group.dev.dependencies]
 # Testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,6 +83,7 @@ tqdm>=4.65.0
 typing-extensions>=4.7.0
 pathlib>=1.0.1
 pyspellchecker>=0.7.2
+scikit-learn>=1.3.0
 
 # Knowledge Graph (If Neo4j is used)
 neo4j>=5.10.0 # Assuming Neo4j is used as hinted by KnowledgeGraphManager


### PR DESCRIPTION
## Summary
- implement keyword extraction using scikit‑learn
- expose `extract_keywords` in analytics module
- add scikit-learn dependency
- test keyword extraction logic

## Testing
- `pytest legal_ai_system/tests/test_keyword_extractor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6848af49697c8323b0e8da595dd7d267