### PR TITLE
Integrate spaCy and Legal-BERT NER

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ tual environment and run the tests:
 python legal_ai_system/scripts/setup_environment_task.py
 ```
 
+### Extraction Options
+
+The ontology extraction agent supports multiple NER backends. Enable them in
+`config/defaults.yaml`:
+
+- `enable_spacy_ner`: load a spaCy pipeline specified by `spacy_ner_model`.
+- `enable_legal_bert`: use a HuggingFace Legal‑BERT model defined by
+  `legal_bert_model_name`.
+- `enable_regex_extraction`: apply regex patterns from the configuration files.
+
+All enabled methods are combined with confidence weighting during extraction.
+
 
 ### Start Task
 

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -91,12 +91,16 @@ cache_ttl_hours: null
 max_cache_size_mb: null
 rate_limit_per_minute: null
 enable_request_logging: true
-enable_data_encryption: false
-encryption_key_path: null
-test_data_dir: /workspace/Legal-AI-ssistant/legal_ai_system/tests/data
-enable_test_mode: false
-enable_agent_debugging: false
-save_intermediate_results: false
-agents:
-  legal_reasoning_engine_config: {}
-  knowledge_graph_reasoning_agent_config: {}
+  enable_data_encryption: false
+  encryption_key_path: null
+  test_data_dir: /workspace/Legal-AI-ssistant/legal_ai_system/tests/data
+  enable_test_mode: false
+  enable_agent_debugging: false
+  save_intermediate_results: false
+  enable_spacy_ner: false
+  spacy_ner_model: en_core_web_sm
+  enable_legal_bert: false
+  legal_bert_model_name: nlpaueb/legal-bert-base-uncased
+  agents:
+    legal_reasoning_engine_config: {}
+    knowledge_graph_reasoning_agent_config: {}

--- a/docs/system_layout.md
+++ b/docs/system_layout.md
@@ -25,8 +25,10 @@ The project defines several specialized agents under `legal_ai_system/agents`:
 - Supports `process_video_depositions`, `process_legal_forms`, and `process_contract_redlines` for specialized legal content.
 - **DocumentRewriterAgent** – performs lightweight spelling correction on extracted text.  See `document_rewriter_agent.py` lines 1‑7.
 - Uses `pyspellchecker` to clean common OCR mistakes before analysis.
-- **OntologyExtractionAgent** – extracts legal entities and relationships using ontology‑driven patterns.  See `ontology_extraction_agent.py` lines 1‑7.
-- Integrates with the knowledge graph to ensure entities are linked consistently.
+- **OntologyExtractionAgent** – extracts legal entities and relationships using ontology‑driven patterns.
+  It can optionally load a spaCy NER pipeline and a HuggingFace Legal‑BERT model
+  to supplement the regex patterns. All NER outputs are merged with confidence
+  weighting. See `ontology_extraction_agent.py` for details.
 - **EntityExtractionAgent** – streamlined entity extraction for legal documents.  See `entity_extraction_agent.py` lines 1‑7.
 - Focused on speed and identifies names of parties, statutes, and case citations.
 - **SemanticAnalysisAgent** – summarization and legal topic identification.  See `semantic_analysis_agent.py` lines 1‑8.


### PR DESCRIPTION
## Summary
- extend OntologyExtractionAgent with optional spaCy and Legal-BERT NER models
- combine regex, spaCy, and Legal-BERT results in a new `_extract_with_ner`
- update process flow to use NER combination
- expose configuration flags in defaults.yaml
- document new options in README and system layout

## Testing
- `black legal_ai_system/agents/ontology_extraction_agent.py`
- `isort legal_ai_system/agents/ontology_extraction_agent.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6848af48b6c48323b5f6d0142a4f98d6