### PR TITLE
Add metrics and Redis caching

### DIFF
--- a/legal_ai_system/core/vector_store.py
+++ b/legal_ai_system/core/vector_store.py
@@ -30,6 +30,7 @@ import tenacity  # For retries
 
 # Core imports
 from .detailed_logging import LogCategory, detailed_log_function, get_detailed_logger
+from .agent_unified_config import _get_service_sync
 from .unified_exceptions import ConfigurationError, DatabaseError, VectorStoreError
 
 # Initialize loggers for this module
@@ -290,9 +291,13 @@ class VectorStore:
         document_index_path: str | None = None,
         entity_index_path: str | None = None,
         service_config: Optional[Dict[str, Any]] = None,
+        cache_manager: Optional[Any] = None,
+        metrics_exporter: Optional[Any] = None,
     ):
         vector_store_logger.info("=== VectorStore: Instance Creation START ===")
         self.config = service_config or {}
+        self.cache_manager = cache_manager
+        self.metrics = metrics_exporter
         self.storage_path = Path(storage_path_str)
         self.document_index_path = (
             Path(document_index_path)
@@ -1338,6 +1343,17 @@ class VectorStore:
                 duration_add,
                 {"content_len": len(content_to_embed)},
             )
+            if self.metrics:
+                self.metrics.observe_vector_add(duration_add)
+            if self.cache_manager:
+                try:
+                    await self.cache_manager.set(
+                        f"vec_meta:{vector_id}",
+                        metadata_to_store.to_dict(),
+                        ttl_seconds=self.config.get("metadata_cache_ttl", 3600),
+                    )
+                except Exception:
+                    pass
             return vector_id
 
     def _generate_unique_vector_id(self, index_target: str, doc_ref: str) -> str:
@@ -1600,6 +1616,8 @@ class VectorStore:
                     "faiss_time_sec": search_duration_faiss,
                 },
             )
+            if self.metrics:
+                self.metrics.observe_vector_search(total_search_pipeline_duration)
             return results
 
     async def _get_metadata_by_faiss_internal_id_async(
@@ -1607,13 +1625,26 @@ class VectorStore:
     ) -> Optional[VectorMetadata]:
 
         """Retrieves metadata for a given vector_id, checking cache first."""
+        vector_id = await self._get_vector_id_by_faiss_id_async(faiss_id, index_target)
+        if not vector_id:
+            return None
+
+        # Check in-memory cache
         if vector_id in self.metadata_mem_cache:
             self.stats.cache_hits_session += 1
-            self.metadata_mem_cache[vector_id].last_accessed_iso = datetime.now(
-                timezone.utc
-            ).isoformat()
-            self.metadata_mem_cache[vector_id].access_count += 1
-            return self.metadata_mem_cache[vector_id]
+            meta = self.metadata_mem_cache[vector_id]
+            meta.last_accessed_iso = datetime.now(timezone.utc).isoformat()
+            meta.access_count += 1
+            return meta
+
+        # Check Redis cache
+        if self.cache_manager:
+            cached = await self.cache_manager.get(f"vec_meta:{vector_id}")
+            if cached:
+                self.stats.cache_hits_session += 1
+                meta = VectorMetadata.from_row_dict(cached)
+                self.metadata_mem_cache[vector_id] = meta
+                return meta
 
         self.stats.cache_misses_session += 1
         vs_cache_logger.debug(
@@ -1627,6 +1658,13 @@ class VectorStore:
         if row_dict:
             metadata = VectorMetadata.from_row_dict(row_dict)
             self.metadata_mem_cache[vector_id] = metadata  # Add to cache
+            if self.cache_manager:
+                try:
+                    await self.cache_manager.set(
+                        f"vec_meta:{vector_id}", metadata.to_dict(), ttl_seconds=self.config.get("metadata_cache_ttl", 3600)
+                    )
+                except Exception:
+                    pass
             return metadata
         return None
 
@@ -2217,5 +2255,7 @@ def create_vector_store(
         document_index_path=vs_cfg.get("DOCUMENT_INDEX_PATH"),
         entity_index_path=vs_cfg.get("ENTITY_INDEX_PATH"),
         service_config=vs_cfg,
+        cache_manager=getattr(_get_service_sync(service_container, "persistence_manager"), "cache_manager", None),
+        metrics_exporter=_get_service_sync(service_container, "metrics_exporter"),
     )
     return vs_instance

--- a/legal_ai_system/services/metrics_exporter.py
+++ b/legal_ai_system/services/metrics_exporter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from prometheus_client import Counter, Histogram, start_http_server
+from prometheus_client import Counter, Histogram, Gauge, start_http_server
 
 from ..core.detailed_logging import get_detailed_logger, LogCategory
 
@@ -24,6 +24,40 @@ class MetricsExporter:
             "Total number of workflow errors",
         )
 
+        # Knowledge graph query metrics
+        self.kg_queries_total = Counter(
+            "knowledge_graph_queries_total",
+            "Total number of knowledge graph queries",
+        )
+        self.kg_query_cache_hits = Counter(
+            "knowledge_graph_query_cache_hits_total",
+            "Total knowledge graph query cache hits",
+        )
+
+        # Vector store performance metrics
+        self.vector_add_seconds = Histogram(
+            "vector_store_add_seconds",
+            "Time spent adding vectors to the store",
+        )
+        self.vector_search_seconds = Histogram(
+            "vector_store_search_seconds",
+            "Time spent searching the vector store",
+        )
+
+        # Connection pool gauges
+        self.pg_pool_in_use = Gauge(
+            "pg_pool_in_use_connections",
+            "Number of PostgreSQL connections currently in use",
+        )
+        self.pg_pool_free = Gauge(
+            "pg_pool_free_connections",
+            "Number of free PostgreSQL connections",
+        )
+        self.redis_pool_in_use = Gauge(
+            "redis_pool_in_use_connections",
+            "Approximate number of Redis connections in use",
+        )
+
     def observe_workflow_time(self, duration: float) -> None:
         """Record workflow execution duration."""
         self.workflow_execution_seconds.observe(duration)
@@ -31,6 +65,46 @@ class MetricsExporter:
     def inc_workflow_error(self) -> None:
         """Increment the workflow error counter."""
         self.workflow_errors_total.inc()
+
+    # --- Knowledge graph metrics ---
+
+    def inc_kg_query(self, cache_hit: bool = False) -> None:
+        """Increment knowledge graph query counters."""
+        self.kg_queries_total.inc()
+        if cache_hit:
+            self.kg_query_cache_hits.inc()
+
+    # --- Vector store metrics ---
+
+    def observe_vector_add(self, duration: float) -> None:
+        """Record duration of vector add operation."""
+        self.vector_add_seconds.observe(duration)
+
+    def observe_vector_search(self, duration: float) -> None:
+        """Record duration of vector search operation."""
+        self.vector_search_seconds.observe(duration)
+
+    # --- Connection pool metrics ---
+
+    def update_pool_metrics(
+        self, pg_in_use: int = 0, pg_free: int = 0, redis_in_use: int = 0
+    ) -> None:
+        """Update gauges for connection pool utilization."""
+        self.pg_pool_in_use.set(pg_in_use)
+        self.pg_pool_free.set(pg_free)
+        self.redis_pool_in_use.set(redis_in_use)
+
+    def snapshot(self) -> dict:
+        """Return current metric values for health endpoints."""
+        return {
+            "kg_queries_total": self.kg_queries_total._value.get(),
+            "kg_query_cache_hits": self.kg_query_cache_hits._value.get(),
+            "vector_add_seconds_sum": self.vector_add_seconds._sum.get(),
+            "vector_search_seconds_sum": self.vector_search_seconds._sum.get(),
+            "pg_pool_in_use": self.pg_pool_in_use._value.get(),
+            "pg_pool_free": self.pg_pool_free._value.get(),
+            "redis_pool_in_use": self.redis_pool_in_use._value.get(),
+        }
 
 
 metrics_exporter: Optional[MetricsExporter] = None


### PR DESCRIPTION
## Summary
- extend `MetricsExporter` with gauges/counters for knowledge graph, vector store, and pool metrics
- integrate Redis caching in `KnowledgeGraphManager` queries
- add metrics hooks in vector store operations and caching
- expose pool metrics through persistence health check
- broadcast metric snapshots via `RealtimePublisher`
- wire metrics into startup and system health endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError & SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_6848af3cce548323aec6f1b37e578bbf