### PR TITLE
Add docs on enhanced langgraph workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ separately:
 pip install langgraph==0.0.20
 ```
 
-See [advanced_langgraph.md](docs/advanced_langgraph.md) for details on how the
-package integrates with document routing and WebSocket progress updates.
+The [advanced LangGraph guide](docs/advanced_langgraph.md) explains how this
+optional dependency enables document classification routing, specialized
+subgraphs, and real-time progress updates over WebSocket. It also shows a
+`CaseWorkflowState` example for passing state between nodes.
 
 For more detailed instructions see [ENV_SETUP.md](ENV_SETUP.md).
 
@@ -89,4 +91,5 @@ See the documents in the `docs/` folder for architecture details and advanced
 usage. The [Integration Guide](docs/integration_plan.md) summarises the
 five-phase integration plan, WebSocket patterns and deployment tips and
 includes sections on security, testing, success metrics and troubleshooting.
-For LangGraph specific routing examples see [advanced_langgraph.md](docs/advanced_langgraph.md).
+For LangGraph specific routing examples and details on the enhanced workflow
+state model see [advanced_langgraph.md](docs/advanced_langgraph.md).

--- a/docs/advanced_langgraph.md
+++ b/docs/advanced_langgraph.md
@@ -1,6 +1,10 @@
 # Advanced LangGraph Workflows
 
-This page describes how to enable and use the optional `langgraph` package for more complex document processing flows. LangGraph allows the system to route documents through specialized subgraphs based on classification results and exposes real‑time progress events over WebSocket.
+This page explains how to enable and use the optional `langgraph` package for
+the enhanced workflow engine. When installed, LangGraph adds document
+classification routing so each document flows through a specialized subgraph and
+emits real-time progress events over WebSocket. The example `CaseWorkflowState`
+shows how to pass state through the graph.
 
 ## Installation
 
@@ -66,4 +70,7 @@ result = workflow.run(CaseWorkflowState(document_id="123"))
 ```
 
 This pattern allows every stage to augment the state and makes the entire workflow easily inspectable.
+
+For integration steps see [integration_plan.md](integration_plan.md). The overall
+service layout is described in [system_layout.md](system_layout.md).
 

--- a/docs/integration_plan.md
+++ b/docs/integration_plan.md
@@ -10,7 +10,7 @@ This guide outlines the five-phase plan for integrating the Legal AI System, com
 4. **Deployment** – Run the FastAPI app with Uvicorn or inside Docker. Ensure environment variables for database connections and secret keys are provided. Build the frontend once and serve the static files from `frontend/dist`.
 5. **Monitoring and Optimization** – Start the `RealtimePublisher` to broadcast system metrics and log performance. Tune database connections and vector stores based on load patterns.
 
-6. **Advanced LangGraph Workflows** – Install the optional `langgraph` package and see [advanced_langgraph.md](advanced_langgraph.md) for classification routing and WebSocket monitoring.
+6. **Enhanced LangGraph Workflow** – Install the optional `langgraph` dependency, then follow [advanced_langgraph.md](advanced_langgraph.md) for setup instructions, classification routing, WebSocket progress monitoring, and the `CaseWorkflowState` example.
 
 ## WebSocket Patterns
 

--- a/docs/system_layout.md
+++ b/docs/system_layout.md
@@ -86,7 +86,9 @@ During processing:
 
 LangGraph based workflows use `AnalysisNode` and `SummaryNode` (see `agents/agent_nodes.py`) which internally retrieve the integration service via the service container to run analysis or summarization.  This allows complex graphs of tasks to be executed with consistent resource management.
 
-For a deep dive into classification routing and specialized subgraphs see [advanced_langgraph.md](advanced_langgraph.md).
+For a deep dive into the enhanced LangGraph workflow, including classification
+routing, specialized subgraphs, and the `CaseWorkflowState` model, see
+[advanced_langgraph.md](advanced_langgraph.md).
 
 ### Typed Workflow Engine
 


### PR DESCRIPTION
## Summary
- expand optional `langgraph` setup instructions in README
- update advanced LangGraph workflow guide with cross-links
- mention enhanced workflow in integration and system layout docs

## Testing
- `pytest legal_ai_system/tests/test_case_workflow_state.py::test_case_workflow_state_basic_operations -q`

------
https://chatgpt.com/codex/tasks/task_e_6848b66ed4148323a2646921cd95f093