### PR TITLE
Add test helper script reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ tual environment and run the tests:
 ```bash
 python legal_ai_system/scripts/setup_environment_task.py
 ```
+For a faster workflow, you can run the helper script below. It automatically
+creates `.venv` if needed, installs all development dependencies, and invokes
+`pytest`:
+
+```bash
+./scripts/run_tests.sh
+```
 
 ### Extraction Options
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -10,11 +10,12 @@ if [ ! -d "$VENV_PATH" ]; then
   python3 -m venv "$VENV_PATH"
 fi
 
+# shellcheck source=/dev/null
 source "$VENV_PATH/bin/activate"
 cd "$REPO_ROOT"
 
-pip install --upgrade pip
-pip install -r requirements.txt
-pip install -e .[dev]
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+python -m pip install -e ".[dev]"
 
 pytest "$@"


### PR DESCRIPTION
## Summary
- refine scripts/run_tests.sh for reliability
- document run_tests.sh in README for a quick test workflow

## Testing
- `./scripts/run_tests.sh` *(fails: pip installation due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6848cc46efac8323b458ea3c365fe11a