### PR TITLE
Fix docs to use frontend npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ If you prefer manual installation:
    The requirements file includes database drivers such as **asyncpg** for PostgreSQL and **aioredis** for Redis. If you see errors like `Import "asyncpg" could not be resolved` or `Import "aioredis" could not be resolved`, ensure the dependencies are installed in the active environment.
 3. Install Node packages for the React frontend:
    ```bash
-   npm install
    (cd frontend && npm install)
    ```
 4. Build the frontend for production (optional when serving via FastAPI):

--- a/docs/developer_onboarding.md
+++ b/docs/developer_onboarding.md
@@ -28,7 +28,6 @@ Welcome to the Legal AI System project! This guide helps new contributors set up
    If you prefer manual installation run:
    ```bash
    pip install -r requirements.txt
-   npm install
    (cd frontend && npm install)
    ```
 4. **Optional extras**

--- a/legal_ai_system/scripts/install_all_dependencies.py
+++ b/legal_ai_system/scripts/install_all_dependencies.py
@@ -8,7 +8,9 @@ from pathlib import Path
 from typing import Iterable
 
 
-def run(cmd: Iterable[str], cwd: Path | None = None, timeout: int = 1800) -> None:
+def run(
+    cmd: Iterable[str], cwd: Path | None = None, timeout: int = 1800
+) -> None:
     """Run a command and raise an error if it fails."""
     print(f"Running: {' '.join(cmd)}")
     # Convert to list to satisfy type checkers expecting ``Sequence[str]``
@@ -63,22 +65,28 @@ def main() -> None:
     pip(venv_path, ["install", "-r", str(repo_root / "requirements.txt")])
     pip(venv_path, ["install", "lexnlp"])
     pip(venv_path, ["install", "langgraph", "sqlalchemy", "lancedb"])
-    pip(venv_path, [
-        "install",
-        "ffmpeg-python",
-        "openai-whisper",
-        "whisperx",
-        "pdfplumber",
-        "pyannote.audio",
-    ])
+    pip(
+        venv_path,
+        [
+            "install",
+            "ffmpeg-python",
+            "openai-whisper",
+            "whisperx",
+            "pdfplumber",
+            "pyannote.audio",
+        ],
+    )
 
     verify_imports(venv_path)
     run_tests(venv_path)
 
     # Node dependencies
-    npm(["install"], cwd=repo_root)
+    root_pkg = repo_root / "package.json"
+    if root_pkg.exists():
+        npm(["install"], cwd=repo_root)
+
     frontend_dir = repo_root / "frontend"
-    if frontend_dir.exists():
+    if (frontend_dir / "package.json").exists():
         npm(["install"], cwd=frontend_dir)
 
     print("All dependencies installed successfully")


### PR DESCRIPTION
## Summary
- remove outdated root `npm install` instructions
- update onboarding docs
- handle missing root `package.json` in dependency installer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6848cc4748788323894b81c153ec6c75