### PR TITLE
Centralize default config and document overrides

### DIFF
--- a/ENV_SETUP.md
+++ b/ENV_SETUP.md
@@ -74,3 +74,19 @@ export LEGAL_AI_LLM_PROVIDER=openai
 
 This would set `llm_provider` to `openai`. Keys are case-insensitive and list
 values can be provided as comma-separated strings.
+
+## Override Mechanism
+`ConfigurationManager` reads the configuration in two phases. First, all default
+values are loaded from `config/defaults.yaml`. Immediately after loading the
+defaults, any environment variable beginning with `LEGAL_AI_` is applied as an
+override. The portion of the variable name following the prefix is matched (in a
+case-insensitive manner) with the YAML keys.
+
+For example, to change the data directory you can set:
+
+```bash
+export LEGAL_AI_DATA_DIR=/tmp/legalai
+```
+
+Boolean values accept `true`, `false`, `1`, `0`, `yes`, or `no`. List-type
+settings can be supplied as comma-separated strings.

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -103,16 +103,16 @@ cache_ttl_hours: null
 max_cache_size_mb: null
 rate_limit_per_minute: null
 enable_request_logging: true
-  enable_data_encryption: false
-  encryption_key_path: null
-  test_data_dir: /workspace/Legal-AI-ssistant/legal_ai_system/tests/data
-  enable_test_mode: false
-  enable_agent_debugging: false
-  save_intermediate_results: false
-  enable_spacy_ner: false
-  spacy_ner_model: en_core_web_sm
-  enable_legal_bert: false
-  legal_bert_model_name: nlpaueb/legal-bert-base-uncased
-  agents:
-    legal_reasoning_engine_config: {}
-    knowledge_graph_reasoning_agent_config: {}
+enable_data_encryption: false
+encryption_key_path: null
+test_data_dir: /workspace/Legal-AI-ssistant/legal_ai_system/tests/data
+enable_test_mode: false
+enable_agent_debugging: false
+save_intermediate_results: false
+enable_spacy_ner: false
+spacy_ner_model: en_core_web_sm
+enable_legal_bert: false
+legal_bert_model_name: nlpaueb/legal-bert-base-uncased
+agents:
+  legal_reasoning_engine_config: {}
+  knowledge_graph_reasoning_agent_config: {}

--- a/legal_ai_system/core/configuration_manager.py
+++ b/legal_ai_system/core/configuration_manager.py
@@ -31,10 +31,10 @@ config_manager_logger = get_detailed_logger("ConfigurationManager", LogCategory.
 
 
 class ConfigurationManager:
-    """
-    Service-oriented configuration manager that provides centralized
-    access to all Legal AI System configuration settings.
-    """
+    """Centralized access to configuration settings."""
+
+    # Path to the YAML file containing default settings
+    DEFAULTS_FILE = Path(__file__).resolve().parents[2] / "config" / "defaults.yaml"
     
     @detailed_log_function(LogCategory.CONFIG)
     def __init__(self, custom_settings_instance: Optional[LegalAISettings] = None): # Renamed for clarity
@@ -61,7 +61,7 @@ class ConfigurationManager:
     @detailed_log_function(LogCategory.CONFIG)
     def _load_defaults(self) -> LegalAISettings:
         """Load default settings from YAML file."""
-        defaults_path = Path(__file__).resolve().parents[2] / "config" / "defaults.yaml"
+        defaults_path = self.DEFAULTS_FILE
         if defaults_path.exists():
             try:
                 with defaults_path.open("r") as f:


### PR DESCRIPTION
## Summary
- fix YAML formatting in `config/defaults.yaml`
- expose `DEFAULTS_FILE` constant in `ConfigurationManager` and load defaults from this YAML before overrides
- document how environment overrides work in `ENV_SETUP.md`

## Testing
- `pytest -q` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6848cc5cc91c8323acf2746ab7f9a151