### PR TITLE
Integrate task queue into realtime workflow

### DIFF
--- a/legal_ai_system/services/realtime_analysis_workflow.py
+++ b/legal_ai_system/services/realtime_analysis_workflow.py
@@ -91,9 +91,11 @@ class RealTimeAnalysisWorkflow:
         self,
         service_container: Any | None = None,
         workflow_config: Any | None = None,
+        task_queue: Any | None = None,
     ) -> None:
         """Initialize workflow settings and state."""
         self.service_container = service_container
+        self.task_queue = task_queue
         self.logger = get_detailed_logger(
             "RealTimeWorkflow", LogCategory.SYSTEM
         )

--- a/legal_ai_system/services/service_container.py
+++ b/legal_ai_system/services/service_container.py
@@ -778,7 +778,9 @@ async def create_service_container(
     await container.register_service(
         "realtime_analysis_workflow",
         factory=lambda sc: RealTimeAnalysisWorkflow(
-            sc, workflow_config=WorkflowConfig(**sc.get_active_workflow_config())
+            sc,
+            workflow_config=WorkflowConfig(**sc.get_active_workflow_config()),
+            task_queue=sc._services.get("task_queue"),
         ),
         is_async_factory=False,
     )

--- a/legal_ai_system/services/workflow_orchestrator.py
+++ b/legal_ai_system/services/workflow_orchestrator.py
@@ -51,10 +51,13 @@ class WorkflowOrchestrator:
             workflow_config = config.get("workflow_config", WorkflowConfig())
 
         # RealTimeAnalysisWorkflow used for async document processing
+        task_queue = config.get("task_queue") or service_container._services.get(
+            "task_queue"
+        )
         self.workflow = RealTimeAnalysisWorkflow(
             service_container,
             workflow_config=workflow_config,
-            **config,
+            task_queue=task_queue,
         )
 
 

--- a/legal_ai_system/tests/test_realtime_workflow_refactor.py
+++ b/legal_ai_system/tests/test_realtime_workflow_refactor.py
@@ -168,4 +168,17 @@ async def test_process_document_realtime_updates_graph_and_vectors() -> None:
     wf._update_vector_store_realtime.assert_awaited()
 
 
+@pytest.mark.asyncio
+async def test_process_document_realtime_queues_job_when_queue_available() -> None:
+    queue = MagicMock()
+    queue.enqueue = MagicMock(return_value="job")
+    wf = DummyWorkflow(queue=queue)
+
+    result = await wf.process_document_realtime("sample.txt")
+
+    assert result == "job"
+    queue.enqueue.assert_called_once()
+    wf._notify_progress.assert_awaited_with("queued", 0.0)
+
+
 


### PR DESCRIPTION
## Summary
- wire up TaskQueue instance when creating `RealTimeAnalysisWorkflow`
- pass the queue through `WorkflowOrchestrator`
- expose queue support through workflow API
- test queue submission logic

## Testing
- `pytest -q` *(fails: missing optional dependencies and parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848cc5e10fc8323bbadc23ad141e514