### PR TITLE
Add new tokens and document StatusDashboard

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -6,7 +6,7 @@ This project uses a small set of design tokens and React components to keep styl
 
 Token values are defined in `frontend/src/design-system/tokens.ts` and include colors, spacing, typography, border radius, shadows and animation speeds. Import tokens into components to avoid magic values.
 
-Recent additions include extended spacing sizes (`2xl`, `3xl`) and light/dark variants for all semantic colors such as `primaryLight` and `primaryDark`.
+Recent additions include extended spacing sizes (`2xl`&ndash;`5xl`) and light, dark, and muted variants for all semantic colors such as `primaryLight`, `primaryDark`, and `primaryMuted`.
 
 Example:
 ```ts
@@ -22,7 +22,7 @@ Currently available:
 - `Card` &ndash; simple container with padding and shadow.
 - `Alert` &ndash; color coded status messages.
 - `Grid` &ndash; layout utility for building responsive grids.
-- `StatusDashboard` &ndash; displays workflow progress using a WebSocket connection. Pass a unique `clientId` to connect to `/ws/{clientId}`.
+- `StatusDashboard` &ndash; displays workflow progress using a WebSocket connection. This component lives in `frontend/src/components` and accepts a unique `clientId` to connect to `/ws/{clientId}`.
 
 These components automatically apply token values so usage is consistent across the application.
 
@@ -32,6 +32,14 @@ These components automatically apply token values so usage is consistent across 
 import { Button } from '../design-system';
 
 <Button variant="primary" size="md">Save</Button>
+```
+
+### Status Dashboard Example
+
+```tsx
+import StatusDashboard from '../components/StatusDashboard';
+
+<StatusDashboard clientId="my-client" />
 ```
 
 When referencing the design system from code outside of the `frontend/src`

--- a/frontend/src/design-system/tokens.ts
+++ b/frontend/src/design-system/tokens.ts
@@ -17,6 +17,12 @@ export const colors = {
   info: '#0EA5E9',
   infoLight: '#38BDF8',
   infoDark: '#0369A1',
+  primaryMuted: '#DBEAFE',
+  secondaryMuted: '#E2E8F0',
+  successMuted: '#DCFCE7',
+  dangerMuted: '#FEE2E2',
+  warningMuted: '#FEF3C7',
+  infoMuted: '#E0F2FE',
   white: '#ffffff',
   black: '#000000',
   gray100: '#F3F4F6',
@@ -38,6 +44,8 @@ export const spacing = {
   xl: '2rem',
   '2xl': '3rem',
   '3xl': '4rem',
+  '4xl': '6rem',
+  '5xl': '8rem',
 };
 
 export const typography = {


### PR DESCRIPTION
## Summary
- extend design tokens with muted color variants and larger spacing sizes
- document new tokens and StatusDashboard usage

## Testing
- `pytest -q legal_ai_system/tests/test_json_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6848cc601894832393cc8875e0981fe6