### PR TITLE
Inject shared ConnectionPool across persistence services

### DIFF
--- a/legal_ai_system/core/enhanced_persistence.py
+++ b/legal_ai_system/core/enhanced_persistence.py
@@ -896,6 +896,12 @@ class CacheManager:
 
 class EnhancedPersistenceManager:
     """Central persistence manager coordinating all data operations."""
+
+    def __init__(
+        self,
+        connection_pool: ConnectionPool,
+        config: Optional[Dict[str, Any]] | None = None,
+    ) -> None:
         self.config = config or {}
         cache_ttl = self.config.get("cache_default_ttl_seconds", 3600)
 
@@ -903,7 +909,9 @@ class EnhancedPersistenceManager:
         self.entity_repo = EntityRepository(self.connection_pool)
         self.relationship_repo = RelationshipRepository(self.connection_pool)
         self.workflow_repo = WorkflowRepository(self.connection_pool)
-        self.cache_manager = CacheManager(self.connection_pool, default_ttl_seconds=cache_ttl)
+        self.cache_manager = CacheManager(
+            self.connection_pool, default_ttl_seconds=cache_ttl
+        )
         self.metrics = metrics_exporter
         self.initialized = False
         self.logger = persistence_logger.getChild("Manager")
@@ -1130,5 +1138,10 @@ class EnhancedPersistenceManager:
 
 # Factory function for service container
 def create_enhanced_persistence_manager(
-
-    )
+    service_container: "ServiceContainer",
+    *,
+    connection_pool: ConnectionPool,
+    config: Optional[Dict[str, Any]] | None = None,
+) -> EnhancedPersistenceManager:
+    """Factory for :class:`ServiceContainer`."""
+    return EnhancedPersistenceManager(connection_pool=connection_pool, config=config)


### PR DESCRIPTION
## Summary
- initialize `KnowledgeGraphManager` and `EnhancedVectorStore` with a `ConnectionPool`
- update `_init_persistence` to use the shared pool when present
- provide factories compatible with `ServiceContainer`
- prevent duplicate pool closing in `EnhancedVectorStore`
- add factory for `EnhancedPersistenceManager`

## Testing
- `pytest -q` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6848cd5342608323b2f258b7927157ea