### PR TITLE
Add analytics integration for dashboard

### DIFF
--- a/legal_ai_system/tests/test_dashboard_data_retrieval.py
+++ b/legal_ai_system/tests/test_dashboard_data_retrieval.py
@@ -1,0 +1,89 @@
+import datetime
+from legal_ai_system.services.database_manager import DatabaseManager
+from legal_ai_system.agents.violation_review import ViolationReviewEntry
+
+
+def test_dashboard_data_retrieval(tmp_path):
+    db_file = tmp_path / "dashboard.db"
+    manager = DatabaseManager(str(db_file))
+
+    # Insert documents with entity results
+    manager.save_document("d1", "a.txt", "txt", 10, {})
+    manager.save_document("d2", "b.txt", "txt", 20, {})
+    manager.update_document_status(
+        "d1", "COMPLETED", {"entities": [{"type": "PERSON"}, {"type": "ORG"}]}
+    )
+    manager.update_document_status(
+        "d2", "IN_PROGRESS", {"entities": [{"type": "PERSON"}]}
+    )
+
+    # Insert violations using the review manager so they are stored correctly
+    manager.violation_manager.insert_violation(
+        ViolationReviewEntry(
+            id="v1",
+            case_id="d1",
+            actor="system",
+            violation_type="Data",
+            description="desc",
+            status="PENDING",
+            metadata={"severity": "HIGH", "confidence": 0.9},
+        )
+    )
+    manager.violation_manager.insert_violation(
+        ViolationReviewEntry(
+            id="v2",
+            case_id="d2",
+            actor="system",
+            violation_type="Privacy",
+            description="desc",
+            status="RESOLVED",
+            metadata={"severity": "LOW", "confidence": 0.8},
+        )
+    )
+
+    # Also record violations in the main database for analytics
+    with manager._get_connection() as conn:
+        conn.execute(
+            "INSERT INTO violations (id, document_id, violation_type, severity, status, description, confidence, detected_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "v1",
+                "d1",
+                "Data",
+                "HIGH",
+                "PENDING",
+                "desc",
+                0.9,
+                datetime.datetime.now(),
+            ),
+        )
+        conn.execute(
+            "INSERT INTO violations (id, document_id, violation_type, severity, status, description, confidence, detected_time) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "v2",
+                "d2",
+                "Privacy",
+                "LOW",
+                "RESOLVED",
+                "desc",
+                0.8,
+                datetime.datetime.now(),
+            ),
+        )
+        conn.commit()
+
+    docs = manager.get_documents()
+    assert len(docs) == 2
+
+    # Aggregate entities from documents
+    entities = []
+    for doc in docs:
+        entities.extend(doc.get("results", {}).get("entities", []))
+    assert len(entities) == 3
+
+    violations = manager.get_violations()
+    assert len(violations) == 2
+    assert len([v for v in violations if v.status == "PENDING"]) == 1
+
+    metrics = manager.get_analytics_data()
+    assert metrics["documents"]["total"] == 2
+    assert metrics["violations"]["pending"] == 1

--- a/legal_ai_system/utils/unified_gui.py
+++ b/legal_ai_system/utils/unified_gui.py
@@ -996,7 +996,9 @@ class WorkflowDesignerTab:
             current = workflows[workflow_names.index(selection)]
 
         name = st.text_input("Name", value=current.get("name", "") if current else "")
-        enable_ner = st.checkbox("Enable NER", value=current.get("enable_ner", True) if current else True)
+        enable_ner = st.checkbox(
+            "Enable NER", value=current.get("enable_ner", True) if current else True
+        )
         enable_llm = st.checkbox(
             "Enable LLM Extraction",
             value=current.get("enable_llm_extraction", True) if current else True,
@@ -1023,7 +1025,9 @@ class WorkflowDesignerTab:
             if result.get("status") != "ERROR":
                 ErrorHandler.display_success("Workflow saved")
             else:
-                ErrorHandler.display_error("Failed to save workflow", result.get("message"))
+                ErrorHandler.display_error(
+                    "Failed to save workflow", result.get("message")
+                )
 
 
 class SettingsLogsTab:
@@ -1295,19 +1299,19 @@ class AnalysisDashboardTab:
         db = DatabaseManager()
         raw_metrics = db.get_analytics_data()
 
+        total_docs = raw_metrics.get("documents", {}).get("total", 0)
+        processed_docs = raw_metrics.get("documents", {}).get("processed", 0)
+        total_violations = raw_metrics.get("violations", {}).get("total", 0)
+        pending_violations = raw_metrics.get("violations", {}).get("pending", 0)
+
         metrics = {
-            "documents_processed": raw_metrics.get("documents", {}).get(
-                "processed", 0
-            ),
-            "documents_delta": 0,
-            "active_workflows": raw_metrics.get("knowledge_graph", {}).get(
-                "nodes", 0
-            ),
-            "workflows_delta": 0,
-            "pending_reviews": raw_metrics.get("violations", {}).get(
-                "pending", 0
-            ),
-            "reviews_delta": 0,
+            "documents_processed": processed_docs,
+            # show total documents as delta value for quick reference
+            "documents_delta": total_docs,
+            "active_workflows": raw_metrics.get("knowledge_graph", {}).get("nodes", 0),
+            "workflows_delta": raw_metrics.get("knowledge_graph", {}).get("edges", 0),
+            "pending_reviews": pending_violations,
+            "reviews_delta": total_violations,
             "system_health": f"{raw_metrics.get('documents', {}).get('success_rate', 0):.0f}%",
         }
 
@@ -1366,9 +1370,7 @@ class AnalysisDashboardTab:
                     if isinstance(ent, dict):
                         entities.append(ent)
 
-            fig_entities = DataVisualization.create_entity_distribution_chart(
-                entities
-            )
+            fig_entities = DataVisualization.create_entity_distribution_chart(entities)
             st.plotly_chart(fig_entities, use_container_width=True)
 
         # Document analysis
@@ -1388,8 +1390,8 @@ class AnalysisDashboardTab:
 
         with col2:
             # Document status distribution
-            if not docs_df.empty and "status" in docs_df.columns:
-                status_counts = docs_df["status"].value_counts()
+            if not docs_df.empty and "processing_status" in docs_df.columns:
+                status_counts = docs_df["processing_status"].value_counts()
                 fig_status = px.bar(
                     x=status_counts.values,
                     y=status_counts.index,
@@ -1456,7 +1458,7 @@ class AnalysisDashboardTab:
                     value=compliance_score,
                     domain={"x": [0, 1], "y": [0, 1]},
                     title={"text": "Compliance Score"},
-                    gauge={"axis": {"range": [None, 100]}}
+                    gauge={"axis": {"range": [None, 100]}},
                 )
             )
             st.plotly_chart(fig_compliance, use_container_width=True)


### PR DESCRIPTION
## Summary
- compute dashboard metrics from `DatabaseManager.get_analytics_data`
- fix document status column handling
- add regression tests for dashboard data retrieval using a temporary DB

## Testing
- `pytest legal_ai_system/tests/test_dashboard_analytics.py legal_ai_system/tests/test_dashboard_data_retrieval.py -q`
- `pytest -q` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848cdf6ead4832386f5b935700a48b6