### PR TITLE
Add keyword extractor module with tests

### DIFF
--- a/legal_ai_system/analytics/keyword_extractor.py
+++ b/legal_ai_system/analytics/keyword_extractor.py
@@ -1,4 +1,9 @@
-"""Keyword extraction utilities."""
+"""Keyword extraction utilities.
+
+This module provides a lightweight TF-IDF based keyword extractor.  The
+``extract_keywords`` function returns the top scoring terms from a single
+document.
+"""
 
 from __future__ import annotations
 
@@ -8,7 +13,7 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 
 
 def extract_keywords(text: str, top_k: int = 5) -> List[Tuple[str, float]]:
-    """Return the top *top_k* keywords ranked by TF-IDF score.
+    """Return the top ``top_k`` keywords ranked by TF-IDF score.
 
     Parameters
     ----------
@@ -22,12 +27,15 @@ def extract_keywords(text: str, top_k: int = 5) -> List[Tuple[str, float]]:
     List[Tuple[str, float]]
         Keyword-score pairs sorted in descending order.
     """
-    if not text.strip() or top_k <= 0:
+    # Guard against empty input or invalid ``top_k``
+    if not text or not text.strip() or top_k <= 0:
         return []
 
     vectorizer = TfidfVectorizer(stop_words="english")
     tfidf_matrix = vectorizer.fit_transform([text])
     scores = tfidf_matrix.toarray()[0]
     features = vectorizer.get_feature_names_out()
+
+    # Pair each term with its TF-IDF score and sort by score descending
     ranked = sorted(zip(features, scores), key=lambda x: x[1], reverse=True)
     return ranked[:top_k]

--- a/legal_ai_system/tests/test_keyword_extractor.py
+++ b/legal_ai_system/tests/test_keyword_extractor.py
@@ -13,9 +13,18 @@ def test_extract_keywords_ranks_terms():
     keywords = extract_keywords(text, top_k=3)
     assert len(keywords) == 3
     assert keywords[0][0] == "contract"
+    assert keywords[0][1] >= keywords[1][1] >= keywords[2][1]
     assert any(k == "agreement" for k, _ in keywords)
 
 
 @pytest.mark.unit
 def test_extract_keywords_empty_text_returns_empty_list():
     assert extract_keywords("", top_k=5) == []
+    assert extract_keywords("   ", top_k=2) == []
+
+
+@pytest.mark.unit
+def test_extract_keywords_respects_top_k():
+    text = "alpha beta gamma delta epsilon"
+    keywords = extract_keywords(text, top_k=2)
+    assert len(keywords) == 2


### PR DESCRIPTION
## Summary
- implement TF-IDF keyword extractor
- add tests covering ranking and `top_k`

## Testing
- `pytest -q legal_ai_system/tests/test_keyword_extractor.py`

------
https://chatgpt.com/codex/tasks/task_e_6848cdf0d77083238573f34dfed1bf2f