### PR TITLE
Add shared memory support

### DIFF
--- a/docs/shared_memory.md
+++ b/docs/shared_memory.md
@@ -1,0 +1,12 @@
+# Shared Memory Usage
+
+The unified memory manager now exposes helper methods for storing data that is accessible to all agents within a session.
+
+Use `store_shared_memory` and `retrieve_shared_memory` from `AgentConfigHelper` or the memory mixin to exchange information between agents.
+
+```python
+helper.store_shared_memory(key="summary", value={"text": "..."}, session_id=session_id)
+other = helper.retrieve_shared_memory(key="summary", session_id=session_id)
+```
+
+Agents mixing in `AgentMemoryMixin` gain `store_shared_memory()` and `retrieve_shared_memory()` methods to work with shared session knowledge.

--- a/legal_ai_system/tests/test_shared_memory.py
+++ b/legal_ai_system/tests/test_shared_memory.py
@@ -1,0 +1,19 @@
+import pytest
+from pathlib import Path
+
+from legal_ai_system.core.unified_memory_manager import UnifiedMemoryManager
+
+
+@pytest.mark.asyncio
+async def test_shared_memory_between_agents(tmp_path: Path) -> None:
+    db_path = tmp_path / "umm.db"
+    mm = UnifiedMemoryManager(db_path_str=str(db_path))
+    await mm.initialize()
+
+    session_id = "sess1"
+    await mm.store_shared_memory(session_id=session_id, key="item", value={"a": 1})
+
+    value = await mm.retrieve_shared_memory(session_id=session_id, key="item")
+    assert value == {"a": 1}
+
+    await mm.close()


### PR DESCRIPTION
## Summary
- extend agent memory table with `memory_type`
- store and retrieve agent memory with the new field
- add helper methods for shared session memory
- document shared memory usage
- test shared memory functions

## Testing
- `pytest -q legal_ai_system/tests/test_shared_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_6848d24a1f7c8323bb5eca6246799a14