### PR TITLE
Add CaseWorkflowState persistence through orchestrator

### DIFF
--- a/legal_ai_system/services/workflow_orchestrator.py
+++ b/legal_ai_system/services/workflow_orchestrator.py
@@ -149,7 +149,7 @@ class WorkflowOrchestrator:
             text = extract_text(Path(document_path_str))
             if case_state is not None:
                 case_state.process_new_document(result.document_id, text)
-                graph_input = case_state.get_case_context()
+                graph_input = case_state
             else:
                 graph_input = text
 

--- a/legal_ai_system/workflows/case_workflow_state.py
+++ b/legal_ai_system/workflows/case_workflow_state.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, Any
+from typing import Dict, Any, List
 
 
 @dataclass
@@ -10,15 +10,17 @@ class CaseWorkflowState:
 
     case_id: str
     documents: Dict[str, str] = field(default_factory=dict)
+    document_order: List[str] = field(default_factory=list)
     state_data: Dict[str, Any] = field(default_factory=dict)
 
     def process_new_document(self, document_id: str, document_text: str) -> None:
-        """Store the text for a processed document."""
+        """Store the text for a processed document in submission order."""
         self.documents[document_id] = document_text
+        self.document_order.append(document_id)
 
     def get_case_context(self) -> str:
-        """Aggregate text from all processed documents."""
-        return "\n".join(self.documents.values())
+        """Aggregate text from all processed documents in order."""
+        return "\n".join(self.documents[doc_id] for doc_id in self.document_order)
 
     def update_case_state(self, new_data: Dict[str, Any]) -> None:
         """Merge additional metadata into the case state."""


### PR DESCRIPTION
## Summary
- enhance `CaseWorkflowState` to track document order
- update `WorkflowOrchestrator` to forward state object to the graph
- extend state persistence tests with dummy container and dependency stubs

## Testing
- `pytest legal_ai_system/tests/test_case_workflow_state.py::test_workflow_orchestrator_state_persistence -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6848d520c360832387f8d256798c2902