### PR TITLE
Improve Streamlit startup

### DIFF
--- a/legal_ai_system/__main__.py
+++ b/legal_ai_system/__main__.py
@@ -36,13 +36,14 @@ def run_system():  # Renamed from main for clarity
         # This function should handle its own setup (logging, etc.) and then run Streamlit.
         main_streamlit_entry()
         return 0  # Success
-    except ModuleNotFoundError:
+    except ModuleNotFoundError as e:
+        missing = getattr(e, "name", str(e))
         print(
-            "ERROR: Streamlit GUI module not found at 'legal_ai_system/gui/streamlit_app.py'.",
+            f"ERROR: Missing dependency '{missing}' required for the Streamlit GUI.",
             file=sys.stderr,
         )
         print(
-            "Please ensure the GUI component is present and your PYTHONPATH includes the 'legal_ai_system' package.",
+            "Install required packages with: pip install -r requirements.txt",
             file=sys.stderr,
         )
         return 1


### PR DESCRIPTION
## Summary
- avoid hard Sentry dependency and configure via optional env var
- initialize logging earlier for Streamlit GUI
- provide clearer missing dependency message in `__main__`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6849055950c48323bb2f7f633763a9af