### PR TITLE
Add automated BaseNode typing fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ optional dependency enables document classification routing, specialized
 subgraphs, and real-time progress updates over WebSocket. It also shows a
 `CaseWorkflowState` example for passing state between nodes.
 
+If Pylance or other type checkers report assignment errors for ``BaseNode``
+after installing ``langgraph``, run the helper script below. It scans all Python
+files and rewrites optional imports so that the fallback ``BaseNode`` is always
+aliased consistently:
+
+```bash
+python legal_ai_system/scripts/fix_langgraph_typing.py
+```
+
 For more detailed instructions see [ENV_SETUP.md](docs/ENV_SETUP.md).
 
 The older `setup_environment_task.py` script can also be used to create the vir

--- a/legal_ai_system/agents/agent_nodes.py
+++ b/legal_ai_system/agents/agent_nodes.py
@@ -6,9 +6,9 @@ import asyncio
 from typing import TYPE_CHECKING
 
 try:  # pragma: no cover - optional dependency
-    from langgraph.graph import BaseNode
+    from langgraph.graph import BaseNode as LangGraphBaseNode
 except Exception:  # ImportError or other issues if langgraph not installed
-    class BaseNode:
+    class LangGraphBaseNode:
         """Minimal stand-in for :class:`langgraph.graph.BaseNode`."""
 
         pass
@@ -66,3 +66,4 @@ class SummaryNode(BaseNode):
 
 
 __all__ = ["AnalysisNode", "SummaryNode"]
+BaseNode = LangGraphBaseNode

--- a/legal_ai_system/scripts/fix_langgraph_typing.py
+++ b/legal_ai_system/scripts/fix_langgraph_typing.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Apply LangGraph typing fixes across the repository.
+
+This script renames fallback ``BaseNode`` definitions to ``LangGraphBaseNode``
+and creates a runtime alias ``BaseNode = LangGraphBaseNode`` to avoid
+``reportAssignmentType`` errors raised by Pylance. Run it from the repository
+root:
+
+    python legal_ai_system/scripts/fix_langgraph_typing.py
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def iter_candidate_files() -> list[Path]:
+    """Return repository Python files that import ``BaseNode`` from LangGraph."""
+    candidates = []
+    for path in REPO_ROOT.rglob("*.py"):
+        if path == Path(__file__):
+            continue
+        if "site-packages" in path.parts or "/.venv/" in str(path):
+            continue
+        text = path.read_text(encoding="utf-8")
+        if "from langgraph.graph import" in text and "BaseNode" in text:
+            candidates.append(path)
+    return candidates
+
+
+def update_file(path: Path) -> bool:
+    """Rewrite imports and fallback classes in ``path`` if needed."""
+    original = path.read_text(encoding="utf-8")
+    lines = original.splitlines()
+    changed = False
+    for i, line in enumerate(lines):
+        if "from langgraph.graph" in line and "BaseNode as" not in line and "BaseNode" in line:
+            lines[i] = line.replace("BaseNode", "BaseNode as LangGraphBaseNode")
+            changed = True
+        if line.lstrip().startswith("class BaseNode"):
+            lines[i] = line.replace("class BaseNode", "class LangGraphBaseNode", 1)
+            changed = True
+    text = "\n".join(lines)
+    if "BaseNode = LangGraphBaseNode" not in text and "class LangGraphBaseNode" in text:
+        text += "\nBaseNode = LangGraphBaseNode\n"
+        changed = True
+    if changed:
+        path.write_text(text + ("" if text.endswith("\n") else "\n"), encoding="utf-8")
+    return changed
+
+
+def main() -> None:
+    changed_any = False
+    for path in iter_candidate_files():
+        if update_file(path):
+            print(f"Updated {path.relative_to(REPO_ROOT)}")
+            changed_any = True
+    if not changed_any:
+        print("No changes required.")
+
+
+if __name__ == "__main__":
+    main()

--- a/legal_ai_system/workflows/langgraph_setup.py
+++ b/legal_ai_system/workflows/langgraph_setup.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 try:  # pragma: no cover - optional dependency
-    from langgraph.graph import StateGraph, END, BaseNode
+    from langgraph.graph import StateGraph, END, BaseNode as LangGraphBaseNode
 except Exception:  # pragma: no cover - during tests
     class StateGraph:  # pragma: no cover - simple placeholder
         def __init__(self) -> None:
@@ -25,7 +25,7 @@ except Exception:  # pragma: no cover - during tests
 
     END = "END"
 
-    class BaseNode:
+    class LangGraphBaseNode:
         pass
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -66,3 +66,4 @@ def build_advanced_legal_workflow(topic: str) -> StateGraph:
 
 
 __all__ = ["build_graph", "build_advanced_legal_workflow", "CitationCheckNode"]
+BaseNode = LangGraphBaseNode


### PR DESCRIPTION
## Summary
- handle `BaseNode` aliasing across the repo with an improved `fix_langgraph_typing.py` script
- document the script's repo‑wide search
- update `agent_nodes.py` and `langgraph_setup.py` with runtime aliasing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_6848dfc3efd8832381eaecaf06ab2232