### PR TITLE
Add review queue API and GUI integration

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,17 @@
 // Centralized API client for backend REST endpoints
-import { WorkflowConfig, WorkflowConfigCreate, DocumentUploadResponse, ProcessingRequest, DocumentStatusResponse } from "../types/workflow";
+import {
+  WorkflowConfig,
+  WorkflowConfigCreate,
+  DocumentUploadResponse,
+  ProcessingRequest,
+  DocumentStatusResponse,
+} from "../types/workflow";
+import {
+  ReviewItem,
+  ReviewDecisionRequest,
+  ReviewDecisionResponse,
+  ReviewStats,
+} from "../types/review";
 
 async function handleResponse<T>(res: Response): Promise<T> {
   if (!res.ok) {
@@ -49,4 +61,25 @@ export async function processDocument(documentId: string, request: ProcessingReq
 export async function getDocumentStatus(documentId: string): Promise<DocumentStatusResponse> {
   const res = await fetch(`/api/v1/documents/${documentId}/status`);
   return handleResponse<DocumentStatusResponse>(res);
+}
+
+export async function fetchPendingReviews(limit = 20): Promise<ReviewItem[]> {
+  const res = await fetch(`/api/v1/reviews/pending?limit=${limit}`);
+  return handleResponse<ReviewItem[]>(res);
+}
+
+export async function submitReviewDecision(
+  data: ReviewDecisionRequest
+): Promise<ReviewDecisionResponse> {
+  const res = await fetch(`/api/v1/reviews/decision`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  return handleResponse<ReviewDecisionResponse>(res);
+}
+
+export async function fetchReviewStats(): Promise<ReviewStats> {
+  const res = await fetch(`/api/v1/reviews/stats`);
+  return handleResponse<ReviewStats>(res);
 }

--- a/frontend/src/components/ReviewQueue.tsx
+++ b/frontend/src/components/ReviewQueue.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect } from 'react';
+import useLoadingState from '../hooks/useLoadingState';
+import { ReviewItem, ReviewDecisionRequest } from '../types/review';
+import { fetchPendingReviews, submitReviewDecision } from '../api/client';
+
+const ReviewQueue: React.FC = () => {
+  const { isLoading, error, data, executeAsync, setData } =
+    useLoadingState<ReviewItem[]>();
+
+  useEffect(() => {
+    executeAsync(() => fetchPendingReviews());
+  }, []);
+
+  const handleDecision = async (itemId: string, decision: string) => {
+    const req: ReviewDecisionRequest = { item_id: itemId, decision };
+    try {
+      await submitReviewDecision(req);
+      setData(data?.filter((i) => i.item_id !== itemId) || null);
+    } catch {
+      // ignore error for now
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl font-bold">Pending Reviews</h2>
+      {isLoading && <div>Loading...</div>}
+      {error && <div className="text-red-600">Failed to load reviews</div>}
+      {data &&
+        data.map((item) => (
+          <div key={item.item_id} className="border p-4 rounded">
+            <div className="font-medium mb-2">
+              {item.item_type} ({item.confidence.toFixed(2)})
+            </div>
+            <pre className="text-sm bg-gray-100 p-2 rounded overflow-auto">
+              {JSON.stringify(item.content, null, 2)}
+            </pre>
+            <div className="mt-2 flex gap-2">
+              <button
+                className="px-2 py-1 bg-green-600 text-white rounded"
+                onClick={() => handleDecision(item.item_id, 'approved')}
+              >
+                Approve
+              </button>
+              <button
+                className="px-2 py-1 bg-red-600 text-white rounded"
+                onClick={() => handleDecision(item.item_id, 'rejected')}
+              >
+                Reject
+              </button>
+            </div>
+          </div>
+        ))}
+    </div>
+  );
+};
+
+export default ReviewQueue;

--- a/frontend/src/legal-ai-gui.tsx
+++ b/frontend/src/legal-ai-gui.tsx
@@ -12,6 +12,7 @@ import {
   DashboardErrorBoundary,
   DocumentProcessingErrorBoundary,
 } from '@/components/AsyncErrorBoundary';
+import ReviewQueue from '@/components/ReviewQueue';
 
 
 
@@ -85,6 +86,11 @@ export default function LegalAISystem() {
                   <WorkflowDesigner />
                 </ErrorBoundary>
               )}
+              {currentView === 'reviews' && (
+                <ErrorBoundary level="view">
+                  <ReviewQueue />
+                </ErrorBoundary>
+              )}
               {currentView === 'monitoring' && (
                 <ErrorBoundary level="view">
                   <Monitoring />
@@ -118,6 +124,7 @@ function Sidebar() {
     { id: 'knowledge', label: 'Knowledge Graph', icon: Network },
     { id: 'agents', label: 'Agent Management', icon: Cpu },
     { id: 'workflows', label: 'Workflow Designer', icon: Workflow },
+    { id: 'reviews', label: 'Review Queue', icon: Eye },
     { id: 'monitoring', label: 'Monitoring', icon: Activity },
     { id: 'security', label: 'Security', icon: Shield },
     { id: 'settings', label: 'Settings', icon: Settings }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from "./status";
 export * from "./workflow";
+export * from "./review";

--- a/frontend/src/types/review.ts
+++ b/frontend/src/types/review.ts
@@ -1,0 +1,38 @@
+export interface ReviewItem {
+  item_id: string;
+  item_type: string;
+  content: Record<string, any>;
+  confidence: number;
+  source_document_id: string;
+  extraction_context?: Record<string, any> | null;
+  review_status: string;
+  review_priority: string;
+  created_at: string;
+  reviewed_at?: string | null;
+  reviewer_id?: string | null;
+  reviewer_notes?: string | null;
+}
+
+export interface ReviewDecisionRequest {
+  item_id: string;
+  decision: string;
+  modified_content?: Record<string, any> | null;
+  reviewer_notes?: string | null;
+  confidence_override?: number | null;
+}
+
+export interface ReviewDecisionResponse {
+  status: string;
+  item_id: string;
+}
+
+export interface ReviewStats {
+  status_counts: Record<string, number>;
+  priority_counts_pending: Record<string, number>;
+  pending_reviews_total: number;
+  new_items_last_24h: number;
+  auto_approve_thresh: number;
+  review_thresh: number;
+  reject_thresh: number;
+  db_path: string;
+}

--- a/legal_ai_system/api/review_models.py
+++ b/legal_ai_system/api/review_models.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from ..utils.reviewable_memory import ReviewStatus, ReviewPriority
+
+
+class ReviewItem(BaseModel):
+    """Representation of an item awaiting review."""
+
+    item_id: str
+    item_type: str
+    content: Dict[str, Any]
+    confidence: float
+    source_document_id: str
+    extraction_context: Optional[Dict[str, Any]] = None
+    review_status: ReviewStatus
+    review_priority: ReviewPriority
+    created_at: datetime
+    reviewed_at: Optional[datetime] = None
+    reviewer_id: Optional[str] = None
+    reviewer_notes: Optional[str] = None
+
+
+class ReviewDecisionRequest(BaseModel):
+    """Payload for submitting a review decision."""
+
+    item_id: str
+    decision: ReviewStatus
+    modified_content: Optional[Dict[str, Any]] = None
+    reviewer_notes: Optional[str] = None
+    confidence_override: Optional[float] = Field(None, ge=0.0, le=1.0)
+    reviewer_id: Optional[str] = None
+
+
+class ReviewDecisionResponse(BaseModel):
+    status: str
+    item_id: str
+
+
+class ReviewStatsResponse(BaseModel):
+    status_counts: Dict[str, int]
+    priority_counts_pending: Dict[str, int]
+    pending_reviews_total: int
+    new_items_last_24h: int
+    auto_approve_thresh: float
+    review_thresh: float
+    reject_thresh: float
+    db_path: str


### PR DESCRIPTION
## Summary
- add review Pydantic models
- extend FastAPI backend with pending review, decision and stats routes
- expose review endpoints to frontend API client
- add React ReviewQueue component and navigation

## Testing
- `python -m py_compile legal_ai_system/scripts/main.py`
- `npm run type-check` *(fails: Cannot find module 'react')*
- `./scripts/run_tests.sh` *(fails to finish due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6849596bf5e08323b52129ba360ff3b7