### PR TITLE
Use dataclasses.asdict for serialization

### DIFF
--- a/legal_ai_system/agents/citation_analysis_agent.py
+++ b/legal_ai_system/agents/citation_analysis_agent.py
@@ -59,9 +59,7 @@ class CitationAnalysisOutput: # Renamed from CitationAnalysisResult for consiste
     analyzed_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
 
     def to_dict(self) -> Dict[str, Any]:
-        data = asdict(self)
-        data['citations_found'] = [c.to_dict() for c in self.citations_found]
-        return data
+        return asdict(self)
 
 
 class CitationAnalysisAgent(BaseAgent, MemoryMixin):

--- a/legal_ai_system/agents/document_processor_agent.py
+++ b/legal_ai_system/agents/document_processor_agent.py
@@ -204,11 +204,7 @@ class DocumentProcessingOutput:
     )
 
     def to_dict(self) -> Dict[str, Any]:
-        data = asdict(self)
-        data["document_content_type"] = (
-            self.document_content_type.value
-        )  # Store enum value
-        return data
+        return asdict(self)
 
 
 class DocumentProcessorAgent(BaseAgent, MemoryMixin):

--- a/legal_ai_system/agents/knowledge_base_agent.py
+++ b/legal_ai_system/agents/knowledge_base_agent.py
@@ -9,7 +9,7 @@ available."""
 import hashlib
 import json
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from datetime import datetime
 from functools import lru_cache
 from typing import Any, Dict, List, Optional, Set
@@ -137,28 +137,7 @@ class EntityResolutionResult:
     processing_time: float
 
     def to_dict(self) -> Dict[str, Any]:
-        return {
-            "resolved_entities": [
-                {
-                    "entity_id": e.entity_id,
-                    "canonical_name": e.canonical_name,
-                    "entity_type": e.entity_type,
-                    "aliases": list(e.aliases),
-                    "attributes": e.attributes,
-                    "confidence_score": e.confidence_score,
-                    "source_documents": list(e.source_documents),
-                    "relationships": e.relationships,
-                    "created_at": e.created_at.isoformat(),
-                    "updated_at": e.updated_at.isoformat(),
-                }
-                for e in self.resolved_entities
-            ],
-            "resolution_metrics": self.resolution_metrics,
-            "organizational_structure": self.organizational_structure,
-            "analytical_insights": self.analytical_insights,
-            "processing_time": self.processing_time,
-            "resolved_at": datetime.now().isoformat(),
-        }
+        return asdict(self)
 
 
 class KnowledgeBaseAgent(BaseAgent):

--- a/legal_ai_system/agents/legal_agents.py
+++ b/legal_ai_system/agents/legal_agents.py
@@ -1,6 +1,6 @@
 """Lightweight validation agents for the Violation Review GUI."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 from typing import Optional, Dict, Any
 
 from ..services.violation_review import ViolationReviewEntry
@@ -17,13 +17,7 @@ class AgentRecommendation:
     followup_tool: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
-        return {
-            "agent": self.agent_name,
-            "summary": self.summary,
-            "recommendation": self.recommendation,
-            "confidence": self.confidence,
-            "followup_tool": self.followup_tool,
-        }
+        return asdict(self)
 
 
 class LegalAuditAgent:

--- a/legal_ai_system/agents/ontology_extraction_agent.py
+++ b/legal_ai_system/agents/ontology_extraction_agent.py
@@ -102,12 +102,7 @@ class OntologyExtractionOutput:
     overall_confidence: float = 0.0
 
     def to_dict(self) -> Dict[str, Any]:
-        # Ensure nested dataclasses are also converted if they have custom to_dict for some reason
-        # asdict usually handles this well for simple dataclasses.
-        data = asdict(self)
-        data["entities"] = [e.to_dict() for e in self.entities]
-        data["relationships"] = [r.to_dict() for r in self.relationships]
-        return data
+        return asdict(self)
 
 
 class OntologyExtractionAgent(BaseAgent, MemoryMixin):

--- a/legal_ai_system/agents/structural_analysis_agent.py
+++ b/legal_ai_system/agents/structural_analysis_agent.py
@@ -43,22 +43,7 @@ class StructuralAnalysisResult:
     )  # Added
 
     def to_dict(self) -> Dict[str, Any]:
-        data = asdict(self)
-        # Ensure IRAC components are initialized if not present after asdict
-        if "irac_components" not in data or not data["irac_components"]:
-            data["irac_components"] = {
-                "issues": [],
-                "rules": [],
-                "application": [],
-                "conclusion": [],
-            }
-        else:
-            for key in ["issues", "rules", "application", "conclusion"]:
-                if key not in data["irac_components"]:
-                    data["irac_components"][key] = (
-                        [] if key in ["issues", "rules"] else ""
-                    )
-        return data
+        return asdict(self)
 
 
 class StructuralAnalysisAgent(BaseAgent, MemoryMixin):

--- a/legal_ai_system/agents/violation_detector_agent.py
+++ b/legal_ai_system/agents/violation_detector_agent.py
@@ -55,9 +55,7 @@ class ViolationDetectionOutput:
     model_used_for_llm: Optional[str] = None  # Track LLM model if used
 
     def to_dict(self) -> Dict[str, Any]:
-        data = asdict(self)
-        data["violations_found"] = [v.to_dict() for v in self.violations_found]
-        return data
+        return asdict(self)
 
 
 class ViolationDetectorAgent(BaseAgent, MemoryMixin):

--- a/legal_ai_system/core/vector_store.py
+++ b/legal_ai_system/core/vector_store.py
@@ -106,9 +106,7 @@ class SearchResult:
     rank: int
 
     def to_dict(self) -> Dict[str, Any]:
-        data = asdict(self)
-        data["metadata"] = self.metadata.to_dict()
-        return data
+        return asdict(self)
 
 
 @dataclass

--- a/legal_ai_system/services/realtime_analysis_workflow.py
+++ b/legal_ai_system/services/realtime_analysis_workflow.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 from types import SimpleNamespace
 from datetime import datetime
 from collections import defaultdict
@@ -73,18 +73,7 @@ class RealTimeAnalysisResult:
     sync_status: Dict[str, str]
 
     def to_dict(self) -> Dict[str, Any]:
-        return {
-            "document_path": self.document_path,
-            "document_id": self.document_id,
-            "processing_times": self.processing_times,
-            "total_processing_time": self.total_processing_time,
-            "confidence_scores": self.confidence_scores,
-            "validation_results": self.validation_results,
-            "sync_status": self.sync_status,
-            "graph_updates": self.graph_updates,
-            "vector_updates": self.vector_updates,
-            "memory_updates": self.memory_updates,
-        }
+        return asdict(self)
 
 
 class RealTimeAnalysisWorkflow:

--- a/legal_ai_system/tests/test_document_processor.py
+++ b/legal_ai_system/tests/test_document_processor.py
@@ -8,6 +8,10 @@ import pytest
 import yaml  # type: ignore
 
 from legal_ai_system.agents.document_processor_agent import DocumentProcessorAgent
+from legal_ai_system.agents.document_processor_agent import (
+    DocumentProcessingOutput,
+    DocumentContentType,
+)
 
 
 @pytest.mark.asyncio
@@ -54,4 +58,23 @@ async def test_process_json_and_yaml(tmp_path: Path) -> None:
 
     res_yaml = await agent.process(yaml_path)
     assert "b: 2" in res_yaml.data["text_content"]
+
+
+def test_document_processing_output_to_dict() -> None:
+    output = DocumentProcessingOutput(
+        file_path="foo.txt",
+        file_name="foo.txt",
+        file_size_bytes=4,
+        document_content_type=DocumentContentType.TXT,
+        processing_strategy_used="test",
+        text_content="foo",
+    )
+    data = output.to_dict()
+    expected_keys = {
+        "file_path",
+        "file_name",
+        "file_size_bytes",
+        "document_content_type",
+    }
+    assert expected_keys.issubset(set(data.keys()))
 

--- a/legal_ai_system/utils/hybrid_extractor.py
+++ b/legal_ai_system/utils/hybrid_extractor.py
@@ -6,7 +6,7 @@ Combines multiple extraction methods for comprehensive legal entity extraction.
 """
 
 import asyncio
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -62,17 +62,7 @@ class HybridExtractionResult:
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for serialization."""
-        return {
-            "document_id": self.document_id,
-            "document_path": self.document_path,
-            "total_entities_found": self.total_entities_found,
-            "high_confidence_entities": self.high_confidence_entities,
-            "extraction_methods_used": self.extraction_methods_used,
-            "processing_time": self.processing_time,
-            "confidence_scores": self.confidence_scores,
-            "validation_results": self.validation_results,
-            "created_at": self.created_at.isoformat(),
-        }
+        return asdict(self)
 
 
 class HybridLegalExtractor(BaseAgent):

--- a/legal_ai_system/utils/reviewable_memory.py
+++ b/legal_ai_system/utils/reviewable_memory.py
@@ -72,12 +72,7 @@ class ReviewableItem:
     original_content_on_modify: Optional[Dict[str, Any]] = None # Renamed, stores original if modified
     
     def to_dict(self) -> Dict[str, Any]: # For serialization
-        data = asdict(self)
-        data['review_status'] = self.review_status.value
-        data['review_priority'] = self.review_priority.value
-        data['created_at'] = self.created_at.isoformat()
-        data['reviewed_at'] = self.reviewed_at.isoformat() if self.reviewed_at else None
-        return data
+        return asdict(self)
 
 @dataclass
 class ReviewDecision:
@@ -103,10 +98,7 @@ class LegalFindingItem: # Renamed from LegalFinding to avoid confusion with a po
     review_status: ReviewStatus = ReviewStatus.PENDING # Findings also go through review
     
     def to_dict(self) -> Dict[str, Any]:
-        data = asdict(self)
-        data['created_at'] = self.created_at.isoformat()
-        data['review_status'] = self.review_status.value
-        return data
+        return asdict(self)
 
 class ReviewableMemory:
     """Manages the review process for extracted legal information."""


### PR DESCRIPTION
## Summary
- simplify `to_dict` methods for dataclasses using `asdict`
- import `asdict` where needed
- add regression test for `DocumentProcessingOutput.to_dict`

## Testing
- `pytest legal_ai_system/tests/test_document_processor.py::test_document_processing_output_to_dict -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684959f3d9fc8323b117151d3e928260