### PR TITLE
Update README with PyQt6 GUI details

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,19 @@ choose the one that suits your workflow:
    development. Use `npm run build` to generate `frontend/dist`, which FastAPI
    serves automatically when present.
 
+### PyQt6 Interface
+
+Install `PyQt6` and launch the desktop GUI module:
+
+```bash
+pip install PyQt6
+python -m legal_ai_system.gui.main_gui
+```
+
+This interface can open local documents and run the default analysis workflow
+without a browser. It is primarily a demo and lacks the advanced features of the
+Streamlit and React frontends.
+
 Detailed instructions are available in [docs/gui_setup.md](docs/gui_setup.md).
 
 ### Extraction Options

--- a/docs/gui_setup.md
+++ b/docs/gui_setup.md
@@ -32,6 +32,9 @@ pip install PyQt6
 
 This GUI lets you open a document and run the default analysis graph locally.
 
+See the [PyQt6 Interface](../README.md#pyqt6-interface) section in the main
+README for a summary of its capabilities and limitations.
+
 
 ## React Frontend
 


### PR DESCRIPTION
## Summary
- document PyQt6 interface in README
- link PyQt6 section from GUI setup docs

## Testing
- `./scripts/run_tests.sh` *(fails: environment doesn't allow full dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68495d3d956083239c61fe43c7a6d8f7