### PR TITLE
Improve realtime KG update and tests

### DIFF
--- a/legal_ai_system/services/realtime_analysis_workflow.py
+++ b/legal_ai_system/services/realtime_analysis_workflow.py
@@ -106,12 +106,14 @@ class RealTimeAnalysisWorkflow:
             confidence_threshold=0.75,
             max_concurrent_documents=1,
             auto_optimization_threshold=1000,
+            min_entity_confidence_for_kg=0.6,
         )
 
         self.enable_real_time_sync = cfg.enable_real_time_sync
         self.confidence_threshold = cfg.confidence_threshold
         self.max_concurrent_documents = cfg.max_concurrent_documents
         self.auto_optimization_threshold = cfg.auto_optimization_threshold
+        self.min_entity_confidence_for_kg = cfg.min_entity_confidence_for_kg
 
         # Performance tracking
         self.documents_processed = 0
@@ -284,7 +286,7 @@ class RealTimeAnalysisWorkflow:
             await self._notify_progress("graph_update", 0.55)
             if self.policy_learner.should_run_step("graph_update", doc_features):
                 t0 = time.time()
-                graph_updates = await self._process_entities_realtime(
+                graph_updates = await self._update_knowledge_graph_realtime(
                     hybrid_result, ontology_result, document_id
                 )
                 duration = time.time() - t0
@@ -390,63 +392,76 @@ class RealTimeAnalysisWorkflow:
         )
         return result
 
-    async def _process_entities_realtime(
+    async def _update_knowledge_graph_realtime(
         self, hybrid_result, ontology_result, document_id: str
     ) -> Dict[str, Any]:
-        """Process entities in real-time and update knowledge graph."""
-        graph_updates = {
-            "nodes_created": 0,
-            "nodes_updated": 0,
-            "edges_created": 0,
-            "edges_updated": 0,
-            "hybrid_entities_processed": 0,
-            "ontology_entities_processed": 0,
-        }
+        """Persist extracted entities and relationships to the knowledge graph."""
+
+        summary = {"nodes_added": 0, "relationships_added": 0}
 
         try:
-            # Loop through each hybrid extraction result and persist it
-            # immediately to the graph if the confidence level meets the
-            # configured threshold.
-            for entity in hybrid_result.validated_entities:
-                if entity.confidence >= self.confidence_threshold:
-                    node_id = await self.graph_manager.process_entity_realtime(
-                        self._convert_to_extracted_entity(entity),
-                        document_id,
-                        {"extraction_method": "hybrid"},
-                    )
+            from itertools import chain
 
-                    if node_id:
-                        graph_updates["nodes_created"] += 1
-                        graph_updates["hybrid_entities_processed"] += 1
+            entity_sources = []
+            for ent in getattr(hybrid_result, "validated_entities", []):
+                entity_sources.append((ent, "hybrid"))
+            for ent in getattr(ontology_result, "entities", []):
+                entity_sources.append((ent, "ontology"))
 
-            # Ontology entities are treated separately but follow the same
-            # basic workflow as hybrid entities.
-            for entity in ontology_result.entities:
-                if entity.confidence >= self.confidence_threshold:
-                    node_id = await self.graph_manager.process_entity_realtime(
-                        entity, document_id, {"extraction_method": "ontology"}
-                    )
+            seen_entities: set[tuple[str, str]] = set()
 
-                    if node_id:
-                        graph_updates["nodes_created"] += 1
-                        graph_updates["ontology_entities_processed"] += 1
+            for entity, source in entity_sources:
+                if getattr(entity, "confidence", 0.0) < self.min_entity_confidence_for_kg:
+                    continue
 
-            # Relationships are also streamed into the graph in real time so
-            # that downstream reasoning components always work with the most
-            # current representation of the document.
-            for relationship in ontology_result.relationships:
-                if relationship.confidence >= self.confidence_threshold:
-                    edge_id = await self.graph_manager.process_relationship_realtime(
-                        relationship, document_id, {"extraction_method": "ontology"}
-                    )
+                text = (
+                    getattr(entity, "entity_text", None)
+                    or getattr(entity, "source_text_snippet", "")
+                ).lower()
+                etype = (
+                    getattr(entity, "consensus_type", None)
+                    or getattr(entity, "entity_type", "")
+                ).lower()
+                key = (text, etype)
+                if key in seen_entities:
+                    continue
+                seen_entities.add(key)
 
-                    if edge_id:
-                        graph_updates["edges_created"] += 1
+                converted = (
+                    self._convert_to_extracted_entity(entity)
+                    if hasattr(entity, "consensus_type") and not hasattr(entity, "entity_id")
+                    else entity
+                )
+                node_id = await self.graph_manager.add_entity_realtime(
+                    converted, document_id, {"extraction_method": source}
+                )
+                if node_id:
+                    summary["nodes_added"] += 1
 
-        except Exception as e:
+            seen_rels: set[tuple[str, str, str]] = set()
+            for rel in getattr(ontology_result, "relationships", []):
+                if getattr(rel, "confidence", 0.0) < self.min_entity_confidence_for_kg:
+                    continue
+
+                key = (
+                    str(getattr(rel, "source_entity", "")),
+                    str(getattr(rel, "target_entity", "")),
+                    getattr(rel, "relationship_type", ""),
+                )
+                if key in seen_rels:
+                    continue
+                seen_rels.add(key)
+
+                edge_id = await self.graph_manager.add_relationship_realtime(
+                    rel, document_id, {"extraction_method": "ontology"}
+                )
+                if edge_id:
+                    summary["relationships_added"] += 1
+
+        except Exception as e:  # pragma: no cover - avoid failing test suite
             self.logger.error(f"Real-time graph processing failed: {e}")
 
-        return graph_updates
+        return summary
 
     async def _update_vector_store_realtime(
         self, hybrid_result, document_text: str, document_id: str

--- a/legal_ai_system/services/realtime_graph_manager.py
+++ b/legal_ai_system/services/realtime_graph_manager.py
@@ -248,6 +248,24 @@ class RealTimeGraphManager:
             # raise KnowledgeGraphError(f"Real-time relationship processing failed for doc {document_id}", cause=e)
             return None
 
+    async def add_entity_realtime(
+        self,
+        entity_data: Any,
+        document_id: str,
+        source_metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Wrapper for process_entity_realtime for external callers."""
+        return await self.process_entity_realtime(entity_data, document_id, source_metadata)
+
+    async def add_relationship_realtime(
+        self,
+        relationship_data: Any,
+        document_id: str,
+        source_metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Wrapper for process_relationship_realtime for external callers."""
+        return await self.process_relationship_realtime(relationship_data, document_id, source_metadata)
+
     def register_update_callback(self, callback: Callable[[str, Dict[str, Any]], None]):
         """Register a callback function for graph updates."""
         self.update_callbacks.append(callback)

--- a/legal_ai_system/tests/test_realtime_workflow_refactor.py
+++ b/legal_ai_system/tests/test_realtime_workflow_refactor.py
@@ -103,11 +103,17 @@ class DummyWorkflow(RealTimeAnalysisWorkflow):
             get_review_stats_async=AsyncMock(return_value={}),
             submit_review_decision_async=AsyncMock(return_value=True),
         )
+        self.policy_learner = SimpleNamespace(
+            should_run_step=lambda *a, **k: True,
+            update_agent_stats=lambda *a, **k: None,
+            record_step=lambda *a, **k: None,
+            predict_concurrency=lambda *a, **k: 1,
+        )
 
         # Patch internal helpers
         self._notify_progress = AsyncMock()
         self._notify_update = AsyncMock()
-        self._process_entities_realtime = AsyncMock(return_value={})
+        self._update_knowledge_graph_realtime = AsyncMock(return_value={})
         self._update_vector_store_realtime = AsyncMock(return_value={})
         self._integrate_with_memory = AsyncMock(return_value={})
         self._validate_extraction_quality = AsyncMock(return_value={})
@@ -164,7 +170,7 @@ async def test_process_document_realtime_updates_graph_and_vectors() -> None:
     wf = DummyWorkflow()
     await wf.process_document_realtime("sample.txt")
 
-    wf._process_entities_realtime.assert_awaited()
+    wf._update_knowledge_graph_realtime.assert_awaited()
     wf._update_vector_store_realtime.assert_awaited()
 
 

--- a/legal_ai_system/tests/unit/test_knowledge_graph_update.py
+++ b/legal_ai_system/tests/unit/test_knowledge_graph_update.py
@@ -1,0 +1,87 @@
+import sys
+import asyncio
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+pyd = ModuleType("pydantic")
+pyd.BaseModel = object
+pyd.BaseSettings = object
+def _field(default=None, **kwargs):
+    return default
+pyd.Field = _field
+sys.modules["pydantic"] = pyd
+sys.modules.setdefault(
+    "legal_ai_system.analytics.keyword_extractor", ModuleType("keyword_extractor")
+).extract_keywords = lambda text: []
+if "numpy" not in sys.modules:
+    numpy_stub = ModuleType("numpy")
+    numpy_stub.array = lambda *a, **k: a
+    numpy_stub.ndarray = list
+    sys.modules["numpy"] = numpy_stub
+if "sklearn" not in sys.modules:
+    skl = ModuleType("sklearn")
+    metrics = ModuleType("metrics")
+    metrics.pairwise = ModuleType("pairwise")
+    metrics.pairwise.cosine_similarity = lambda *a, **k: []
+    skl.metrics = metrics
+    fe = ModuleType("feature_extraction")
+    text_mod = ModuleType("text")
+    text_mod.TfidfVectorizer = object
+    fe.text = text_mod
+    skl.feature_extraction = fe
+    linear_model = ModuleType("linear_model")
+    linear_model.LogisticRegression = object
+    skl.linear_model = linear_model
+    sys.modules["sklearn"] = skl
+    sys.modules["sklearn.metrics"] = metrics
+    sys.modules["sklearn.metrics.pairwise"] = metrics.pairwise
+    sys.modules["sklearn.feature_extraction"] = fe
+    sys.modules["sklearn.feature_extraction.text"] = text_mod
+    sys.modules["sklearn.linear_model"] = linear_model
+prom = ModuleType("prometheus_client")
+prom.Counter = prom.Histogram = prom.Gauge = object
+prom.start_http_server = lambda *a, **k: None
+sys.modules["prometheus_client"] = prom
+
+from legal_ai_system.services.realtime_analysis_workflow import RealTimeAnalysisWorkflow
+
+class DummyWorkflow(RealTimeAnalysisWorkflow):
+    def __init__(self):
+        # minimal setup without calling super
+        self.graph_manager = SimpleNamespace(
+            add_entity_realtime=AsyncMock(return_value="e"),
+            add_relationship_realtime=AsyncMock(return_value="r"),
+        )
+        self._convert_to_extracted_entity = lambda e: e
+        self.min_entity_confidence_for_kg = 0.6
+        self.logger = SimpleNamespace(error=lambda *a, **k: None)
+
+@pytest.mark.asyncio
+async def test_update_knowledge_graph_filters_and_deduplicates():
+    wf = DummyWorkflow()
+    hybrid = SimpleNamespace(
+        validated_entities=[
+            SimpleNamespace(entity_text="A", consensus_type="CASE", confidence=0.7),
+            SimpleNamespace(entity_text="A", consensus_type="CASE", confidence=0.9),
+            SimpleNamespace(entity_text="low", consensus_type="CASE", confidence=0.4),
+        ]
+    )
+    ontology = SimpleNamespace(
+        entities=[
+            SimpleNamespace(entity_text="B", entity_type="ORGANIZATION", confidence=0.65),
+            SimpleNamespace(entity_text="A", entity_type="CASE", confidence=0.8),
+        ],
+        relationships=[
+            SimpleNamespace(source_entity="1", target_entity="2", relationship_type="FILED_BY", confidence=0.7),
+            SimpleNamespace(source_entity="1", target_entity="2", relationship_type="FILED_BY", confidence=0.7),
+            SimpleNamespace(source_entity="1", target_entity="2", relationship_type="FILED_BY", confidence=0.4),
+        ],
+    )
+
+    summary = await wf._update_knowledge_graph_realtime(hybrid, ontology, "doc")
+
+    assert summary == {"nodes_added": 2, "relationships_added": 1}
+    assert wf.graph_manager.add_entity_realtime.await_count == 2
+    assert wf.graph_manager.add_relationship_realtime.await_count == 1


### PR DESCRIPTION
## Summary
- add realtime knowledge graph update logic with deduplication
- expose add_entity_realtime and add_relationship_realtime helpers
- adjust workflow refactor tests for new method
- test entity filtering and deduplication

## Testing
- `pytest legal_ai_system/tests/unit/test_knowledge_graph_update.py -q`
- `pytest legal_ai_system/tests/test_realtime_workflow_refactor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684959f1cbf483238b3d72fc17de6185