### PR TITLE
Fix path comment in vector_store

### DIFF
--- a/legal_ai_system/core/vector_store.py
+++ b/legal_ai_system/core/vector_store.py
@@ -1,4 +1,4 @@
-# legal_ai_system/knowledge/vector_store/vector_store.py
+# legal_ai_system/core/vector_store.py
 """
 Vector Store - Consolidated with DETAILED Logging and Full Implementation
 ==========================================================================


### PR DESCRIPTION
## Summary
- fix the stale path comment at the top of `vector_store.py`

## Testing
- `./scripts/run_tests.sh` *(fails: could not complete due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68495a3130208323b85b7e7c63858736