### PR TITLE
Fix keyword extractor implementation

### DIFF
--- a/legal_ai_system/analytics/keyword_extractor.py
+++ b/legal_ai_system/analytics/keyword_extractor.py
@@ -8,14 +8,14 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 
 
 def extract_keywords(text: str, top_k: int = 5) -> List[Tuple[str, float]]:
-
+    """Return the highest ranked keywords using a TF-IDF model.
 
     Parameters
     ----------
-    text: str
+    text : str
         Input document text.
-    top_k: int
-        Number of keywords to return.
+    top_k : int, optional
+        Number of keywords to return, by default 5.
 
     Returns
     -------
@@ -23,6 +23,7 @@ def extract_keywords(text: str, top_k: int = 5) -> List[Tuple[str, float]]:
         Keyword-score pairs sorted in descending order.
     """
 
+    if not text.strip():
         return []
 
     vectorizer = TfidfVectorizer(stop_words="english")


### PR DESCRIPTION
## Summary
- implement proper docstring for `extract_keywords`
- remove stray return statement and handle empty text
- ensure TF-IDF computation runs correctly

## Testing
- `pytest legal_ai_system/tests/test_keyword_extractor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68496593f4f48323a5466bd88329b359