### PR TITLE
Implement EnhancedPersistenceManager constructor

### DIFF
--- a/legal_ai_system/core/enhanced_persistence.py
+++ b/legal_ai_system/core/enhanced_persistence.py
@@ -897,6 +897,12 @@ class CacheManager:
 class EnhancedPersistenceManager:
     """Central persistence manager coordinating all data operations."""
 
+    def __init__(
+        self,
+        connection_pool: ConnectionPool,
+        config: Optional[Dict[str, Any]] = None,
+        metrics_exporter: Optional[Any] = None,
+    ) -> None:
         self.config = config or {}
         cache_ttl = self.config.get("cache_default_ttl_seconds", 3600)
 
@@ -904,6 +910,7 @@ class EnhancedPersistenceManager:
         self.entity_repo = EntityRepository(self.connection_pool)
         self.relationship_repo = RelationshipRepository(self.connection_pool)
         self.workflow_repo = WorkflowRepository(self.connection_pool)
+        self.cache_manager = CacheManager(self.connection_pool, cache_ttl)
         self.metrics = metrics_exporter
         self.initialized = False
         self.logger = persistence_logger.getChild("Manager")


### PR DESCRIPTION
## Summary
- add `__init__` to `EnhancedPersistenceManager`
- initialize repositories, cache manager, config and metrics in constructor

## Testing
- `pytest -k "EnhancedPersistenceManager" -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6849687e765883239e556ba29839a27b