### PR TITLE
Fix keyword extractor docstring

### DIFF
--- a/legal_ai_system/analytics/keyword_extractor.py
+++ b/legal_ai_system/analytics/keyword_extractor.py
@@ -8,13 +8,13 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 
 
 def extract_keywords(text: str, top_k: int = 5) -> List[Tuple[str, float]]:
-
+    """Extract top-ranked keywords from text using TF-IDF.
 
     Parameters
     ----------
-    text: str
+    text : str
         Input document text.
-    top_k: int
+    top_k : int
         Number of keywords to return.
 
     Returns
@@ -22,8 +22,6 @@ def extract_keywords(text: str, top_k: int = 5) -> List[Tuple[str, float]]:
     List[Tuple[str, float]]
         Keyword-score pairs sorted in descending order.
     """
-
-        return []
 
     vectorizer = TfidfVectorizer(stop_words="english")
     tfidf_matrix = vectorizer.fit_transform([text])


### PR DESCRIPTION
## Summary
- clean up `extract_keywords` docstring in `keyword_extractor.py`
- ensure TF-IDF logic runs and return result

## Testing
- `pytest -k keyword_extractor -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684968984eb88323a2bb599b3aafaca8