### PR TITLE
Refactor persistence manager factory usage

### DIFF
--- a/aioredis/__init__.py
+++ b/aioredis/__init__.py
@@ -1,0 +1,1 @@
+from redis.asyncio import *  # type: ignore

--- a/legal_ai_system/tests/test_persistence_integration.py
+++ b/legal_ai_system/tests/test_persistence_integration.py
@@ -2,7 +2,12 @@ import os
 import asyncio
 import pytest
 
-from legal_ai_system.core.enhanced_persistence import create_enhanced_persistence_manager, EntityRecord, EntityStatus
+from legal_ai_system.core.enhanced_persistence import (
+    create_enhanced_persistence_manager,
+    ConnectionPool,
+    EntityRecord,
+    EntityStatus,
+)
 
 @pytest.mark.asyncio
 async def test_entity_create_and_fetch():
@@ -10,7 +15,11 @@ async def test_entity_create_and_fetch():
     if not dsn:
         pytest.skip("TEST_DATABASE_URL not set")
 
-    manager = create_enhanced_persistence_manager({"database_url": dsn})
+    pool = ConnectionPool(dsn, None)
+    manager = create_enhanced_persistence_manager(
+        config={"database_url": dsn},
+        connection_pool=pool,
+    )
     await manager.initialize()
 
     record = EntityRecord(

--- a/scripts/migrate_database.py
+++ b/scripts/migrate_database.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 """Database migration script using EnhancedPersistenceManager."""
 import asyncio
-from legal_ai_system.core.enhanced_persistence import create_enhanced_persistence_manager
+from legal_ai_system.core.enhanced_persistence import (
+    create_enhanced_persistence_manager,
+    ConnectionPool,
+)
 
 async def main():
-    manager = create_enhanced_persistence_manager({})
+    pool = ConnectionPool(None, None)
+    manager = create_enhanced_persistence_manager(config={}, connection_pool=pool)
     await manager.initialize()
     await manager.close()
 


### PR DESCRIPTION
## Summary
- implement `EnhancedPersistenceManager.__init__` and new factory
- update persistence integration test for new manager signature
- adjust migration script to use the new factory
- add an `aioredis` compatibility shim for Python 3.12

## Testing
- `pytest legal_ai_system/tests/test_persistence_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6849688561b483239ce5cdea9cc35b05