### PR TITLE
Fix scikit-learn version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ tqdm = "^4.65.0"
 pathlib = "^1.0.1"
 typing-extensions = "^4.7.0"
 pyspellchecker = "^0.7.2"
-scikit-learn = "^1.3.0"
+scikit-learn = ">=1.3.2,<1.4"
 
 [tool.poetry.group.dev.dependencies]
 # Testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ PyQt6>=6.4.0  # Required for the optional PyQt GUI
 # Data Handling & Numerics
 pandas>=2.0.0
 numpy>=1.24.0 # Optional for embedding_manager, but good to have
-scikit-learn>=1.3.2
+scikit-learn>=1.3.2,<1.4
 
 # LLM & Embedding Providers
 ollama>=0.1.7
@@ -72,4 +72,3 @@ PyYAML>=6.0
 # time
 # typing
 # uuid
-scikit-learn>=1.4.0


### PR DESCRIPTION
## Summary
- remove duplicate scikit-learn entry in `requirements.txt`
- pin scikit-learn to `>=1.3.2,<1.4` across requirements and pyproject
- verify installation with pip dry-run

## Testing
- `pip install 'scikit-learn>=1.3.2,<1.4' --dry-run`
- `pytest -q` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6849689a9b708323a8118a57c7363e16