### PR TITLE
Move memory brain GUI script

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,13 @@ choose the one that suits your workflow:
 
 1. **Streamlit Dashboard** – run `python -m legal_ai_system` after installing
    `requirements.txt`. This launches a browser-based dashboard connected to the
-   backend.
-   development. Use `npm run build` to generate `frontend/dist`, which FastAPI
-   serves automatically when present.
+   backend. Development builds are supported with the React frontend.
+   Use `npm run build` to generate `frontend/dist`, which FastAPI serves
+   automatically when present.
+
+2. **Memory Brain Demo** – run
+   `python -m legal_ai_system.gui.scripts.memory_brain_gui` to launch a focused
+   Streamlit interface for testing the memory management features.
 
 ### PyQt6 Interface
 

--- a/legal_ai_system/gui/scripts/memory_brain_gui.py
+++ b/legal_ai_system/gui/scripts/memory_brain_gui.py
@@ -2,7 +2,7 @@
 
 import streamlit as st
 
-from ..gui.panels.memory_brain_panel import MemoryBrainPanel
+from ..panels.memory_brain_panel import MemoryBrainPanel
 
 
 def main() -> None:

--- a/legal_ai_system/tests/test_memory_brain_gui.py
+++ b/legal_ai_system/tests/test_memory_brain_gui.py
@@ -11,7 +11,7 @@ def test_memory_brain_gui_main(mocker):
         sys.modules,
         {"legal_ai_system.gui.panels.memory_brain_panel": types.SimpleNamespace(MemoryBrainPanel=panel_cls)}
     )
-    module = importlib.import_module("legal_ai_system.scripts.memory_brain_gui")
+    module = importlib.import_module("legal_ai_system.gui.scripts.memory_brain_gui")
     module.main()
     st.set_page_config.assert_called_once_with(page_title="Memory Brain", page_icon="🧠", layout="wide")
     panel_cls.assert_called_once()


### PR DESCRIPTION
## Summary
- move `memory_brain_gui.py` into `legal_ai_system/gui/scripts`
- update imports and tests for new location
- document the Streamlit demo in README

## Testing
- `pytest legal_ai_system/tests/test_memory_brain_gui.py::test_memory_brain_gui_main -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684a5a132bf48323aa524f01374a8d6a