### PR TITLE
Refactor memory brain helpers

### DIFF
--- a/legal_ai_system/gui/memory_brain_core.py
+++ b/legal_ai_system/gui/memory_brain_core.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+"""Shared helpers for Memory Brain functionality."""
+
+import asyncio
+from typing import Any, Dict, List
+
+from ..tools.contradiction_detector import ContradictionDetector, MemoryEntry
+from ..services.memory_service import memory_manager_context
+
+__all__ = [
+    "load_memory_entries",
+    "persist_statement",
+    "run_contradiction_check",
+    "MemoryBrainCore",
+]
+
+
+def load_memory_entries() -> List[MemoryEntry]:
+    """Return stored statement entries from :class:`UnifiedMemoryManager`."""
+
+    async def _load() -> List[MemoryEntry]:
+        async with memory_manager_context() as manager:
+            entries = await manager.get_context_window("memory_brain")
+            return [
+                MemoryEntry(
+                    speaker=e.get("metadata", {}).get("speaker", ""),
+                    statement=e.get("content", ""),
+                    source=e.get("metadata", {}).get("source", ""),
+                )
+                for e in entries
+                if e.get("entry_type") == "statement"
+            ]
+
+    try:
+        return asyncio.run(_load())
+    except Exception:  # pragma: no cover - initialization can fail offline
+        return []
+
+
+def persist_statement(entry: MemoryEntry) -> None:
+    """Persist a statement to the :class:`UnifiedMemoryManager`."""
+
+    async def _store() -> None:
+        async with memory_manager_context() as manager:
+            await manager.add_context_window_entry(
+                session_id="memory_brain",
+                entry_type="statement",
+                content=entry.statement,
+                metadata={"speaker": entry.speaker, "source": entry.source},
+            )
+
+    try:
+        asyncio.run(_store())
+    except Exception:  # pragma: no cover - storage errors are non fatal
+        pass
+
+
+def run_contradiction_check(
+    memory_entries: List[MemoryEntry],
+    speaker: str,
+    statement: str,
+    source: str = "",
+) -> Dict[str, Any]:
+    """Check a statement for contradictions against stored entries."""
+
+    detector = ContradictionDetector(memory_entries)
+    return detector.check(speaker, statement, source)
+
+
+class MemoryBrainCore:
+    """Convenience wrapper maintaining memory state."""
+
+    def __init__(self) -> None:
+        self.memory_entries: List[MemoryEntry] = []
+
+    def load_entries(self) -> None:
+        self.memory_entries = load_memory_entries()
+
+    def add_statement(self, entry: MemoryEntry) -> None:
+        self.memory_entries.append(entry)
+        persist_statement(entry)
+
+    def check(self, speaker: str, statement: str, source: str = "") -> Dict[str, Any]:
+        return run_contradiction_check(self.memory_entries, speaker, statement, source)

--- a/legal_ai_system/gui/panels/memory_brain_panel.py
+++ b/legal_ai_system/gui/panels/memory_brain_panel.py
@@ -2,44 +2,27 @@ from __future__ import annotations
 
 """Streamlit panel for managing memory entries."""
 from typing import Any, Dict, List
-import asyncio
 
 import streamlit as st
 
-from ...tools.contradiction_detector import ContradictionDetector, MemoryEntry
+from ...tools.contradiction_detector import MemoryEntry
 from ...tools import run_tool, register_tool, ToolGuide
-from ...services.memory_service import memory_manager_context
+from ..memory_brain_core import (
+    MemoryBrainCore,
+    run_contradiction_check,
+)
 
 
 class MemoryBrainPanel:
     """Memory Brain panel with multiple tabs."""
 
     def __init__(self) -> None:
-        self.memory_entries: List[MemoryEntry] = []
-        self._load_memory_entries()
+        self.core = MemoryBrainCore()
+        self.core.load_entries()
+        self.memory_entries = self.core.memory_entries
         self._register_tools()
 
-    def _load_memory_entries(self) -> None:
-        """Load memory entries from the :class:`UnifiedMemoryManager`."""
 
-        async def _load() -> None:
-            # Retrieve previously stored statements from UnifiedMemoryManager
-            async with memory_manager_context() as manager:
-                entries = await manager.get_context_window("memory_brain")
-                self.memory_entries = [
-                    MemoryEntry(
-                        speaker=e.get("metadata", {}).get("speaker", ""),
-                        statement=e.get("content", ""),
-                        source=e.get("metadata", {}).get("source", ""),
-                    )
-                    for e in entries
-                    if e.get("entry_type") == "statement"
-                ]
-
-        try:
-            asyncio.run(_load())
-        except Exception:
-            self.memory_entries = []
 
     def _register_tools(self) -> None:
         """Register builtin tools used by this panel."""
@@ -51,27 +34,12 @@ class MemoryBrainPanel:
         def _contradiction_tool(
             speaker: str, statement: str, source: str
         ) -> Dict[str, Any]:
-            detector = ContradictionDetector(self.memory_entries)
-            return detector.check(speaker, statement, source)
+            return run_contradiction_check(
+                self.memory_entries, speaker, statement, source
+            )
 
         register_tool("contradiction_check", _contradiction_tool, guide)
 
-    def _persist_statement(self, entry: MemoryEntry) -> None:
-        """Persist a statement via :class:`UnifiedMemoryManager`."""
-
-        async def _store() -> None:
-            async with memory_manager_context() as manager:
-                await manager.add_context_window_entry(
-                    session_id="memory_brain",
-                    entry_type="statement",
-                    content=entry.statement,
-                    metadata={"speaker": entry.speaker, "source": entry.source},
-                )
-
-        try:
-            asyncio.run(_store())
-        except Exception:
-            pass
 
     def render(self) -> None:
         """Render the Memory Brain panel."""
@@ -84,8 +52,7 @@ class MemoryBrainPanel:
             source = st.text_input("Source")
             if st.button("Add Statement"):
                 entry = MemoryEntry(speaker=speaker, statement=statement, source=source)
-                self.memory_entries.append(entry)
-                self._persist_statement(entry)
+                self.core.add_statement(entry)
                 st.success("Statement added to memory.")
 
         with tabs[1]:

--- a/legal_ai_system/tests/test_memory_brain_core.py
+++ b/legal_ai_system/tests/test_memory_brain_core.py
@@ -1,0 +1,83 @@
+from contextlib import asynccontextmanager
+import sys
+import types
+
+import pytest
+
+sys.modules.setdefault("streamlit", types.SimpleNamespace())
+@asynccontextmanager
+async def _dummy_cm():
+    yield None
+
+sys.modules.setdefault(
+    "legal_ai_system.services.memory_service",
+    types.SimpleNamespace(memory_manager_context=_dummy_cm),
+)
+from legal_ai_system.tools.contradiction_detector import MemoryEntry
+
+
+@asynccontextmanager
+async def _fake_context(entries=None, store_cb=None):
+    class DummyManager:
+        async def get_context_window(self, session_id):
+            return entries or []
+
+        async def add_context_window_entry(self, **kwargs):
+            if store_cb:
+                store_cb(kwargs)
+
+    yield DummyManager()
+
+
+def test_load_memory_entries(mocker):
+    entries = [
+        {"entry_type": "statement", "content": "Rain", "metadata": {"speaker": "Bob", "source": "a"}},
+        {"entry_type": "other", "content": "foo"},
+    ]
+
+    import importlib
+    module = importlib.import_module("legal_ai_system.gui.memory_brain_core")
+    mocker.patch(
+        "legal_ai_system.gui.memory_brain_core.memory_manager_context",
+        lambda: _fake_context(entries=entries),
+    )
+    result = module.load_memory_entries()
+    assert result == [MemoryEntry(speaker="Bob", statement="Rain", source="a")]
+
+
+def test_persist_statement(mocker):
+    recorded = {}
+    def store_cb(kwargs):
+        recorded.update(kwargs)
+
+    import importlib
+    module = importlib.import_module("legal_ai_system.gui.memory_brain_core")
+    mocker.patch(
+        "legal_ai_system.gui.memory_brain_core.memory_manager_context",
+        lambda: _fake_context(store_cb=store_cb),
+    )
+    entry = MemoryEntry(speaker="Ann", statement="Hi", source="b")
+    module.persist_statement(entry)
+    assert recorded["content"] == "Hi"
+    assert recorded["metadata"] == {"speaker": "Ann", "source": "b"}
+
+
+def test_memory_brain_core_add_and_check(mocker):
+    import importlib
+    module = importlib.import_module("legal_ai_system.gui.memory_brain_core")
+    core = module.MemoryBrainCore()
+    mocker.patch(
+        "legal_ai_system.gui.memory_brain_core.persist_statement",
+        lambda e: None,
+    )
+    core.add_statement(MemoryEntry(speaker="Bob", statement="It is raining", source="x"))
+    res = core.check("Bob", "It is not raining", "y")
+    assert res["count"] == 1
+
+
+def test_run_contradiction_check():
+    import importlib
+    module = importlib.import_module("legal_ai_system.gui.memory_brain_core")
+    entries = [MemoryEntry(speaker="Bob", statement="yes", source="s")]
+    result = module.run_contradiction_check(entries, "Bob", "not yes", "x")
+    assert result["count"] == 1


### PR DESCRIPTION
## Summary
- create `memory_brain_core` helper module for loading, persisting and checking
- refactor `MemoryBrainWidget` and `MemoryBrainPanel` to use the shared logic
- add unit tests for the new module

## Testing
- `pytest -q legal_ai_system/tests/test_memory_brain_gui.py legal_ai_system/tests/test_memory_brain_core.py`

------
https://chatgpt.com/codex/tasks/task_e_684a5a1cb2dc8323a018ab42192d7f37