### PR TITLE
Add PyQt document and review windows

### DIFF
--- a/legal_ai_system/gui/__init__.py
+++ b/legal_ai_system/gui/__init__.py
@@ -1,1 +1,19 @@
+"""PyQt GUI package for the Legal AI System."""
 
+from .main_gui import MainWindow
+from .windows import (
+    DocumentViewerWindow,
+    WorkflowDesignerWindow,
+    ReviewQueueWindow,
+    DocumentTableModel,
+    ViolationsTableModel,
+)
+
+__all__ = [
+    "MainWindow",
+    "DocumentViewerWindow",
+    "WorkflowDesignerWindow",
+    "ReviewQueueWindow",
+    "DocumentTableModel",
+    "ViolationsTableModel",
+]

--- a/legal_ai_system/gui/windows/__init__.py
+++ b/legal_ai_system/gui/windows/__init__.py
@@ -1,0 +1,14 @@
+"""Additional windows used by the PyQt GUI."""
+
+from .document_viewer import DocumentViewerWindow
+from .workflow_designer import WorkflowDesignerWindow
+from .review_queue import ReviewQueueWindow
+from .table_models import DocumentTableModel, ViolationsTableModel
+
+__all__ = [
+    "DocumentViewerWindow",
+    "WorkflowDesignerWindow",
+    "ReviewQueueWindow",
+    "DocumentTableModel",
+    "ViolationsTableModel",
+]

--- a/legal_ai_system/gui/windows/document_viewer.py
+++ b/legal_ai_system/gui/windows/document_viewer.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Window for browsing processed documents."""
+
+from PyQt6 import QtWidgets
+
+from ..main_gui import APIClient
+from .table_models import DocumentTableModel
+
+
+class DocumentViewerWindow(QtWidgets.QMainWindow):
+    """Display documents returned by the backend."""
+
+    def __init__(self, api_client: APIClient) -> None:
+        super().__init__()
+        self.api_client = api_client
+        self.setWindowTitle("Document Viewer")
+
+        self.model = DocumentTableModel(api_client)
+        self.view = QtWidgets.QTableView()
+        self.view.setModel(self.model)
+        self.view.setSortingEnabled(True)
+
+        self.filter_edit = QtWidgets.QLineEdit()
+        self.filter_edit.setPlaceholderText("Filter...")
+        self.filter_edit.textChanged.connect(self.model.filter_keyword)
+
+        refresh_btn = QtWidgets.QPushButton("Refresh")
+        refresh_btn.clicked.connect(self.model.fetch)
+
+        top = QtWidgets.QHBoxLayout()
+        top.addWidget(self.filter_edit)
+        top.addWidget(refresh_btn)
+
+        central = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(central)
+        layout.addLayout(top)
+        layout.addWidget(self.view)
+        self.setCentralWidget(central)
+
+        self.model.fetch()
+
+
+__all__ = ["DocumentViewerWindow"]

--- a/legal_ai_system/gui/windows/review_queue.py
+++ b/legal_ai_system/gui/windows/review_queue.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Window presenting the review queue."""
+
+from PyQt6 import QtWidgets
+
+from ..main_gui import APIClient
+from .table_models import ViolationsTableModel
+
+
+class ReviewQueueWindow(QtWidgets.QMainWindow):
+    """Show violations pending review."""
+
+    def __init__(self, api_client: APIClient) -> None:
+        super().__init__()
+        self.api_client = api_client
+        self.setWindowTitle("Review Queue")
+
+        self.model = ViolationsTableModel(api_client)
+        self.view = QtWidgets.QTableView()
+        self.view.setModel(self.model)
+        self.view.setSortingEnabled(True)
+
+        self.filter_edit = QtWidgets.QLineEdit()
+        self.filter_edit.setPlaceholderText("Filter...")
+        self.filter_edit.textChanged.connect(self.model.filter_keyword)
+
+        refresh_btn = QtWidgets.QPushButton("Refresh")
+        refresh_btn.clicked.connect(self.model.fetch)
+
+        top = QtWidgets.QHBoxLayout()
+        top.addWidget(self.filter_edit)
+        top.addWidget(refresh_btn)
+
+        central = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(central)
+        layout.addLayout(top)
+        layout.addWidget(self.view)
+        self.setCentralWidget(central)
+
+        self.model.fetch()
+
+
+__all__ = ["ReviewQueueWindow"]

--- a/legal_ai_system/gui/windows/table_models.py
+++ b/legal_ai_system/gui/windows/table_models.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+"""Reusable QAbstractTableModel implementations for REST data."""
+
+from typing import Any, List
+
+import pandas as pd
+import requests
+from PyQt6 import QtCore
+
+from ..main_gui import APIClient
+
+
+class _BaseRESTTableModel(QtCore.QAbstractTableModel):
+    """Base model that loads table rows from a REST endpoint."""
+
+    def __init__(self, api_client: APIClient, endpoint: str) -> None:
+        super().__init__()
+        self.api_client = api_client
+        self.endpoint = endpoint
+        self._df = pd.DataFrame()
+        self._filtered_df = self._df
+
+    # ------------------------------------------------------------------
+    # Data loading and filtering
+    # ------------------------------------------------------------------
+    def fetch(self) -> None:
+        """Load data from the configured REST endpoint."""
+        url = f"{self.api_client.base_url}{self.endpoint}"
+        try:
+            resp = self.api_client.session.get(url)
+            resp.raise_for_status()
+            data = resp.json()
+            if isinstance(data, dict):
+                data = (
+                    data.get("items")
+                    or data.get("documents")
+                    or data.get("violations")
+                    or []
+                )
+            self._df = pd.DataFrame(data)
+        except Exception:
+            self._df = pd.DataFrame()
+        self._filtered_df = self._df
+        self.layoutChanged.emit()
+
+    def filter_keyword(self, keyword: str) -> None:
+        """Filter rows that contain ``keyword`` in any column."""
+        if not keyword:
+            self._filtered_df = self._df
+        else:
+            mask = self._df.apply(
+                lambda r: r.astype(str).str.contains(keyword, case=False, na=False).any(),
+                axis=1,
+            )
+            self._filtered_df = self._df[mask]
+        self.layoutChanged.emit()
+
+    # ------------------------------------------------------------------
+    # Qt model overrides
+    # ------------------------------------------------------------------
+    def rowCount(self, parent: QtCore.QModelIndex | None = None) -> int:  # type: ignore[override]
+        return len(self._filtered_df.index)
+
+    def columnCount(self, parent: QtCore.QModelIndex | None = None) -> int:  # type: ignore[override]
+        return len(self._filtered_df.columns)
+
+    def data(self, index: QtCore.QModelIndex, role: int = QtCore.Qt.ItemDataRole.DisplayRole) -> Any:  # type: ignore[override]
+        if not index.isValid() or role not in (
+            QtCore.Qt.ItemDataRole.DisplayRole,
+            QtCore.Qt.ItemDataRole.EditRole,
+        ):
+            return None
+        return str(self._filtered_df.iloc[index.row(), index.column()])
+
+    def headerData(
+        self,
+        section: int,
+        orientation: QtCore.Qt.Orientation,
+        role: int = QtCore.Qt.ItemDataRole.DisplayRole,
+    ) -> Any:  # type: ignore[override]
+        if role != QtCore.Qt.ItemDataRole.DisplayRole:
+            return None
+        if orientation == QtCore.Qt.Orientation.Horizontal:
+            cols: List[str] = list(self._filtered_df.columns)
+            return cols[section] if section < len(cols) else None
+        return str(section + 1)
+
+    def sort(self, column: int, order: QtCore.Qt.SortOrder = QtCore.Qt.SortOrder.AscendingOrder) -> None:  # type: ignore[override]
+        cols = list(self._filtered_df.columns)
+        if 0 <= column < len(cols):
+            ascending = order == QtCore.Qt.SortOrder.AscendingOrder
+            self._filtered_df.sort_values(
+                by=cols[column], ascending=ascending, inplace=True, kind="mergesort"
+            )
+            self.layoutChanged.emit()
+
+
+class DocumentTableModel(_BaseRESTTableModel):
+    """Table model for the ``/api/v1/documents`` endpoint."""
+
+    def __init__(self, api_client: APIClient) -> None:
+        super().__init__(api_client, "/api/v1/documents")
+
+
+class ViolationsTableModel(_BaseRESTTableModel):
+    """Table model for the ``/api/v1/violations`` endpoint."""
+
+    def __init__(self, api_client: APIClient) -> None:
+        super().__init__(api_client, "/api/v1/violations")
+
+
+__all__ = ["DocumentTableModel", "ViolationsTableModel"]

--- a/legal_ai_system/gui/windows/workflow_designer.py
+++ b/legal_ai_system/gui/windows/workflow_designer.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Simplistic workflow designer browser."""
+
+from PyQt6 import QtWidgets
+
+from ..main_gui import APIClient
+
+
+class WorkflowDesignerWindow(QtWidgets.QMainWindow):
+    """Display available workflows."""
+
+    def __init__(self, api_client: APIClient) -> None:
+        super().__init__()
+        self.api_client = api_client
+        self.setWindowTitle("Workflow Designer")
+
+        self.table = QtWidgets.QTableWidget()
+        self.table.setColumnCount(2)
+        self.table.setHorizontalHeaderLabels(["ID", "Name"])
+        self.table.horizontalHeader().setStretchLastSection(True)
+
+        refresh_btn = QtWidgets.QPushButton("Refresh")
+        refresh_btn.clicked.connect(self.load_workflows)
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(self.table)
+        layout.addWidget(refresh_btn)
+
+        container = QtWidgets.QWidget()
+        container.setLayout(layout)
+        self.setCentralWidget(container)
+
+        self.load_workflows()
+
+    def load_workflows(self) -> None:
+        workflows = self.api_client.workflows()
+        self.table.setRowCount(len(workflows))
+        for row, wf in enumerate(workflows):
+            self.table.setItem(row, 0, QtWidgets.QTableWidgetItem(wf.get("id", "")))
+            self.table.setItem(row, 1, QtWidgets.QTableWidgetItem(wf.get("name", "")))
+
+
+__all__ = ["WorkflowDesignerWindow"]


### PR DESCRIPTION
## Summary
- provide QAbstractTableModel implementations for REST table data
- add `DocumentViewerWindow`, `ReviewQueueWindow`, and `WorkflowDesignerWindow`
- expose the new windows and table models from `gui` package

## Testing
- `python -m pytest -q` *(fails: 21 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684a9fa48ea483238c012a5a58ee282f