### PR TITLE
Add animated workflow progress widgets

### DIFF
--- a/legal_ai_system/gui/main_gui.py
+++ b/legal_ai_system/gui/main_gui.py
@@ -177,6 +177,9 @@ class UploadTab(QtWidgets.QWidget):
         upload_btn = QtWidgets.QPushButton("Upload && Process")
         upload_btn.clicked.connect(self.upload)
         self.progress = QtWidgets.QProgressBar()
+        self.progress_anim = QtCore.QPropertyAnimation(self.progress, b"value", self)
+        self.progress_anim.setDuration(400)
+        self.progress_anim.setEasingCurve(QtCore.QEasingCurve.Type.InOutCubic)
         self.output = QtWidgets.QTextEdit(readOnly=True)
 
         top = QtWidgets.QHBoxLayout()
@@ -226,10 +229,16 @@ class UploadTab(QtWidgets.QWidget):
             return
         if data.get("type") == "processing_progress":
             prog = int(float(data.get("progress", 0)) * 100)
-            self.progress.setValue(prog)
+            self.progress_anim.stop()
+            self.progress_anim.setStartValue(self.progress.value())
+            self.progress_anim.setEndValue(prog)
+            self.progress_anim.start()
             self.output.append(f"Stage: {data.get('stage')}")
         elif data.get("type") == "processing_complete":
-            self.progress.setValue(100)
+            self.progress_anim.stop()
+            self.progress_anim.setStartValue(self.progress.value())
+            self.progress_anim.setEndValue(100)
+            self.progress_anim.start()
             self.output.append("Completed")
 
 

--- a/legal_ai_system/gui/viewer_windows.py
+++ b/legal_ai_system/gui/viewer_windows.py
@@ -1,0 +1,80 @@
+"""Extra PyQt6 windows for document viewing and analytics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+from .workflow_progress_widget import WorkflowProgressWidget
+
+
+class DocumentViewerWindow(QtWidgets.QMainWindow):
+    """Simple window displaying a document with animated progress."""
+
+    def __init__(self, ws_base_url: str, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Document Viewer")
+        self.resize(600, 400)
+
+        self.text_edit = QtWidgets.QTextEdit(readOnly=True)
+        self.progress_widget = WorkflowProgressWidget(ws_base_url)
+
+        central = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(central)
+        layout.addWidget(self.text_edit)
+        layout.addWidget(self.progress_widget)
+        self.setCentralWidget(central)
+
+        self.progress_widget.start()
+
+    def load_file(self, path: str) -> None:
+        try:
+            content = Path(path).read_text()
+        except Exception:
+            content = "Unable to load file"
+        self.text_edit.setPlainText(content)
+
+    def closeEvent(self, event: QtGui.QCloseEvent) -> None:  # noqa: D401
+        self.progress_widget.stop()
+        super().closeEvent(event)
+
+
+class AnalyticsWindow(QtWidgets.QMainWindow):
+    """Display analytics information with animated indicator."""
+
+    def __init__(self, ws_base_url: str, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Analytics")
+        self.resize(400, 200)
+
+        self.progress_widget = WorkflowProgressWidget(ws_base_url)
+        self.indicator = QtWidgets.QFrame()
+        self.indicator.setFixedHeight(10)
+        self.indicator.setStyleSheet("background-color: #448aff;")
+
+        self.color_anim = QtCore.QPropertyAnimation(self.indicator, b"styleSheet", self)
+        self.color_anim.setDuration(500)
+        self.color_anim.setEasingCurve(QtCore.QEasingCurve.Type.InOutCubic)
+
+        central = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(central)
+        layout.addWidget(self.progress_widget)
+        layout.addWidget(self.indicator)
+        self.setCentralWidget(central)
+
+        self.progress_widget.start()
+
+    def closeEvent(self, event: QtGui.QCloseEvent) -> None:  # noqa: D401
+        self.progress_widget.stop()
+        super().closeEvent(event)
+
+    def animate_indicator(self) -> None:
+        """Pulse the indicator color to draw attention."""
+        self.color_anim.stop()
+        self.color_anim.setStartValue("background-color: #448aff;")
+        self.color_anim.setEndValue("background-color: #82b1ff;")
+        self.color_anim.start()
+
+
+__all__ = ["DocumentViewerWindow", "AnalyticsWindow"]

--- a/legal_ai_system/gui/workflow_progress_widget.py
+++ b/legal_ai_system/gui/workflow_progress_widget.py
@@ -1,0 +1,62 @@
+"""PyQt6 widget showing workflow progress with animated bar."""
+
+from __future__ import annotations
+
+import uuid
+
+from PyQt6 import QtCore, QtWidgets
+
+from .main_gui import WebSocketWorker
+
+
+class WorkflowProgressWidget(QtWidgets.QWidget):
+    """Display workflow progress updates from a WebSocket connection."""
+
+    def __init__(self, ws_base_url: str, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.ws_base = ws_base_url.rstrip("/")
+        self.client_id = uuid.uuid4().hex
+
+        self.progress = QtWidgets.QProgressBar()
+        self.stage_label = QtWidgets.QLabel()
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(self.stage_label)
+        layout.addWidget(self.progress)
+
+        self.animation = QtCore.QPropertyAnimation(self.progress, b"value", self)
+        self.animation.setDuration(400)
+        self.animation.setEasingCurve(QtCore.QEasingCurve.Type.InOutCubic)
+
+        self.ws_worker: WebSocketWorker | None = None
+
+    def start(self) -> None:
+        """Begin listening for workflow progress updates."""
+        url = f"{self.ws_base}/ws/{self.client_id}"
+        topics = ["workflow_progress"]
+        self.ws_worker = WebSocketWorker(url, topics)
+        self.ws_worker.message_received.connect(self.handle_update)
+        self.ws_worker.start()
+
+    def stop(self) -> None:
+        if self.ws_worker:
+            self.ws_worker.stop()
+            self.ws_worker.wait(1000)
+            self.ws_worker = None
+
+    def handle_update(self, data: dict) -> None:
+        if data.get("type") != "workflow_progress":
+            return
+        progress = int(float(data.get("progress", 0)) * 100)
+        stage = data.get("message") or data.get("stage", "")
+        self.stage_label.setText(stage)
+        self.animate_to(progress)
+
+    def animate_to(self, value: int) -> None:
+        self.animation.stop()
+        self.animation.setStartValue(self.progress.value())
+        self.animation.setEndValue(value)
+        self.animation.start()
+
+
+__all__ = ["WorkflowProgressWidget"]


### PR DESCRIPTION
## Summary
- add `WorkflowProgressWidget` that subscribes to `workflow_progress` updates
- implement `DocumentViewerWindow` and `AnalyticsWindow` with animated indicators
- animate UploadTab progress bar with `QPropertyAnimation`

## Testing
- `pytest -q` *(fails: missing dependencies and syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a9fa9639083239e96141e769dc5b0