### PR TITLE
Add services status API and frontend display

### DIFF
--- a/legal_ai_system/scripts/main.py
+++ b/legal_ai_system/scripts/main.py
@@ -468,6 +468,14 @@ class SystemHealthResponse(BaseModel):
     )
 
 
+class ServicesOverviewResponse(BaseModel):
+    services: Dict[str, Dict[str, Any]]
+    active_workflow_config: Dict[str, Any]
+    timestamp: str = PydanticField(
+        default_factory=lambda: datetime.now(tz=timezone.utc).isoformat()
+    )
+
+
 # --- JWT Utilities & Auth Mock ---
 # In a real app, these would use SecurityManager
 def create_access_token(
@@ -1090,6 +1098,23 @@ async def get_system_health_rest(  # Renamed
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Health check failed: {str(e)}",
+        )
+
+
+@app.get("/api/v1/services", response_model=ServicesOverviewResponse)
+async def get_services_overview(
+    service_container: ServiceContainer = Depends(get_service_container),
+):
+    """Return status and config of registered services."""
+    main_api_logger.info("Services overview requested.")
+    try:
+        overview = service_container.get_services_status()
+        return ServicesOverviewResponse(**overview)
+    except Exception as e:
+        main_api_logger.error("Failed to get services overview.", exception=e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to get services status: {str(e)}",
         )
 
 


### PR DESCRIPTION
## Summary
- expose container service status via `get_services_status`
- add `/api/v1/services` FastAPI endpoint
- show service state list in `SystemHealth` UI

## Testing
- `pytest -q` *(fails: 21 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684a9fd0d43c8323a29e1b9100bf9861