### PR TITLE
Add workflow progress WebSocket support

### DIFF
--- a/frontend/src/components/StatusDashboard.tsx
+++ b/frontend/src/components/StatusDashboard.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { Card, Grid } from '../design-system';
-import useWebSocket, { subscribe, unsubscribe } from '../hooks/useWebSocket';
+import useWebSocket from '../hooks/useWebSocket';
 import { spacing, colors } from '../design-system/tokens';
 
 interface WorkflowUpdate {
@@ -15,8 +15,11 @@ export interface StatusDashboardProps {
 
 const StatusDashboard: React.FC<StatusDashboardProps> = ({ clientId }) => {
   const [workflows, setWorkflows] = useState<Record<string, WorkflowUpdate>>({});
-  const { connected, send } = useWebSocket(`/ws/${clientId}`, handleMessage);
-  const subscribed = useRef(false);
+  useWebSocket(
+    `/ws/${clientId}`,
+    handleMessage,
+    ['workflow_progress'],
+  );
 
   function handleMessage(data: any) {
     if (data.type === 'workflow_progress') {
@@ -31,18 +34,6 @@ const StatusDashboard: React.FC<StatusDashboardProps> = ({ clientId }) => {
     }
   }
 
-  useEffect(() => {
-    if (connected && !subscribed.current) {
-      subscribe({ send }, 'workflow_updates');
-      subscribed.current = true;
-    }
-    return () => {
-      if (subscribed.current) {
-        unsubscribe({ send }, 'workflow_updates');
-        subscribed.current = false;
-      }
-    };
-  }, [connected]);
 
   const items = Object.values(workflows);
 

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -5,7 +5,11 @@ export interface WebSocketHook {
   send: (data: any) => void;
 }
 
-export default function useWebSocket(url: string, onMessage: (msg: any) => void): WebSocketHook {
+export default function useWebSocket(
+  url: string,
+  onMessage: (msg: any) => void,
+  topics: string[] = [],
+): WebSocketHook {
   const wsRef = useRef<WebSocket>();
   const reconnectRef = useRef<ReturnType<typeof setTimeout>>();
   const [connected, setConnected] = useState(false);
@@ -42,6 +46,16 @@ export default function useWebSocket(url: string, onMessage: (msg: any) => void)
       wsRef.current.send(JSON.stringify(data));
     }
   };
+
+  // Subscribe to topics when connected
+  useEffect(() => {
+    if (connected && topics.length > 0) {
+      topics.forEach(t => send({ type: 'subscribe', topic: t }));
+      return () => {
+        topics.forEach(t => send({ type: 'unsubscribe', topic: t }));
+      };
+    }
+  }, [connected, topics.join('|')]);
 
   return { connected, send };
 }


### PR DESCRIPTION
## Summary
- emit workflow progress via `ConnectionManager`
- auto-subscribe to topics in `useWebSocket`
- display workflow progress in `StatusDashboard`

## Testing
- `pytest -q` *(fails: NameError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684a9fd33a6c8323824e88d9008a3a5b