### PR TITLE
Implement errors for unimplemented doc actions

### DIFF
--- a/legal_ai_system/gui/legal-ai-pyqt6-integrated.py
+++ b/legal_ai_system/gui/legal-ai-pyqt6-integrated.py
@@ -782,13 +782,17 @@ class IntegratedMainWindow(QMainWindow):
         
     def filterDocuments(self):
         """Filter documents based on criteria"""
-        # Implement filtering logic
-        pass
-        
+        raise NotImplementedError(
+            "Document filtering is not implemented because the required \"
+            "DocumentTableModel\" from 'legal_ai_desktop' is unavailable."
+        )
+
     def exportDocuments(self):
         """Export selected documents"""
-        # Implement export logic
-        pass
+        raise NotImplementedError(
+            "Document exporting is not implemented because the required \"
+            "DocumentTableModel\" from 'legal_ai_desktop' is unavailable."
+        )
         
     def showDocumentContextMenu(self, pos: QPoint):
         """Show context menu for documents"""


### PR DESCRIPTION
## Summary
- raise `NotImplementedError` in `filterDocuments` and `exportDocuments`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684aa9fe0ce88323a42ce5739a694609