### PR TITLE
Fix dev requirements for tests

### DIFF
--- a/docs/test_setup.md
+++ b/docs/test_setup.md
@@ -11,6 +11,9 @@ The core dependencies for running the tests are listed below. They can be instal
 - `pytest-cov` – required because coverage reporting is enabled by default
 - `typer` – required to test the CLI script
 - `streamlit` – used by the GUI script (tests mock this module)
+- `numpy` – used by vector store operations
+- `PyYAML` – configuration parsing in multiple modules
+- `joblib` – saving and loading ML models
 
 Additional packages from `requirements.txt` are needed for the application itself (FastAPI, pydantic, etc.). Development tools come from `requirements-dev.txt`.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,3 +23,9 @@ ipython>=8.14.0
 notebook>=7.0.0
 line-profiler>=4.1.0
 memory-profiler>=0.61.0
+
+# Additional test dependencies
+numpy>=1.24.0
+PyYAML>=6.0
+typer>=0.9.0
+joblib>=1.3.0


### PR DESCRIPTION
## Summary
- include missing libraries for tests
- document extra packages needed for running pytest

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: IndentationError, ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_684ad348279483239ad3761e36b56ee0