### PR TITLE
Implement StateGraph stub with tests

### DIFF
--- a/legal_ai_system/langgraph/graph.py
+++ b/legal_ai_system/langgraph/graph.py
@@ -1,15 +1,4 @@
-"""Local fallback implementation of a minimal workflow graph."""
-
-from __future__ import annotations
-
-import asyncio
-from typing import Any, Awaitable, Callable, Dict, Iterable, List, Tuple
-
-
-END = "END"
-
-
-"""Minimal local stub for the optional :mod:`langgraph` package."""
+"""Minimal fallback implementation of a workflow graph engine."""
 
 from __future__ import annotations
 
@@ -18,53 +7,91 @@ import inspect
 from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional, Tuple
 
 
+END = "END"
+
+
 class BaseNode:
+    """Placeholder base class used when the real package is unavailable."""
+
     pass
 
+
+async def _maybe_await(value: Awaitable | Any) -> Any:
+    """Await ``value`` if needed and return the result."""
+
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+class StateGraph:
+    """Very small workflow graph for environments without LangGraph."""
 
     def __init__(self) -> None:
         self._nodes: Dict[str, Callable[[Any], Any]] = {}
         self._edges: Dict[str, List[str]] = {}
+        self._conditional_edges: Dict[
+            str, List[Tuple[Callable[[Any], bool], str]]
+        ] = {}
+        self._parallel: Dict[str, Tuple[List[str], str]] = {}
+        self._entry_point: Optional[str] = None
+
+    def add_node(self, name: str, node: Callable[[Any], Any]) -> None:
+        """Register ``node`` under ``name``."""
 
         self._nodes[name] = node
 
     def add_edge(self, src: str, dest: str) -> None:
         """Connect ``src`` node to ``dest`` node."""
+
         self._edges.setdefault(src, []).append(dest)
 
     def add_conditional_edges(
-        self,
-        src: str,
-        mapping: Iterable[Tuple[Callable[[Any], bool], str]],
+        self, src: str, mapping: Iterable[Tuple[Callable[[Any], bool], str]]
     ) -> None:
         """Route to different nodes based on predicate results."""
+
         self._conditional_edges[src] = list(mapping)
 
     def add_parallel_nodes(self, src: str, nodes: List[str], merge: str) -> None:
-        """Run ``nodes`` in parallel after ``src`` and send results to ``merge``."""
+        """Run ``nodes`` in parallel after ``src`` and merge via ``merge``."""
+
         self._parallel[src] = (nodes, merge)
 
     def set_entry_point(self, name: str) -> None:
+        self._entry_point = name
 
+    def run(self, state: Any) -> Any:
+        """Execute the graph synchronously starting with ``state``."""
+
+        return asyncio.run(self._run_async(state))
+
+    async def _run_async(self, state: Any) -> Any:
+        if self._entry_point is None:
+            raise RuntimeError("Entry point not set")
+
+        node_name = self._entry_point
+        while node_name != END:
+            func = self._nodes[node_name]
+            state = await _maybe_await(func(state))
 
             # Handle parallel execution if configured
             if node_name in self._parallel:
                 parallel_nodes, merge_node = self._parallel[node_name]
                 results = await asyncio.gather(
-                    *[
-                        _maybe_await(self._nodes[n](state))
-                        for n in parallel_nodes
-                    ]
+                    *[_maybe_await(self._nodes[n](state)) for n in parallel_nodes]
                 )
                 state = await _maybe_await(self._nodes[merge_node](results))
                 node_name = self._next_node(merge_node, state)
                 continue
 
             node_name = self._next_node(node_name, state)
+
         return state
 
     def _next_node(self, current: str, result: Any) -> str:
-        """Determine the next node after ``current`` given ``result``."""
+        """Return the next node name after ``current`` based on ``result``."""
+
         if current in self._conditional_edges:
             for predicate, dest in self._conditional_edges[current]:
                 if predicate(result):
@@ -74,3 +101,4 @@ class BaseNode:
 
 
 __all__ = ["BaseNode", "StateGraph", "END"]
+

--- a/legal_ai_system/tests/conftest.py
+++ b/legal_ai_system/tests/conftest.py
@@ -5,6 +5,15 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+import importlib
 import types
+
+# Expose the local LangGraph stub when the real package is missing
+if importlib.util.find_spec("langgraph") is None:
+    mod = importlib.import_module("legal_ai_system.langgraph")
+    sys.modules.setdefault("langgraph", mod)
+    sys.modules.setdefault(
+        "langgraph.graph", importlib.import_module("legal_ai_system.langgraph.graph")
+    )
 
 

--- a/legal_ai_system/tests/test_stategraph_basic.py
+++ b/legal_ai_system/tests/test_stategraph_basic.py
@@ -1,0 +1,51 @@
+import unittest
+
+from langgraph.graph import StateGraph, END
+
+
+class TestStateGraphBasic(unittest.TestCase):
+    """Verify core StateGraph functionality."""
+
+    def test_single_node(self) -> None:
+        graph = StateGraph()
+        graph.add_node("start", lambda v: v + 1)
+        graph.set_entry_point("start")
+        graph.add_edge("start", END)
+
+        self.assertEqual(graph.run(1), 2)
+
+    def test_edge_execution(self) -> None:
+        graph = StateGraph()
+        graph.add_node("a", lambda v: v + 1)
+        graph.add_node("b", lambda v: v * 2)
+
+        graph.set_entry_point("a")
+        graph.add_edge("a", "b")
+        graph.add_edge("b", END)
+
+        self.assertEqual(graph.run(1), 4)
+
+    def test_conditional_routing(self) -> None:
+        graph = StateGraph()
+        graph.add_node("start", lambda v: v)
+        graph.add_node("pos", lambda v: v + 1)
+        graph.add_node("neg", lambda v: v - 1)
+
+        graph.set_entry_point("start")
+        graph.add_conditional_edges(
+            "start",
+            [
+                (lambda v: v >= 0, "pos"),
+                (lambda v: v < 0, "neg"),
+            ],
+        )
+        graph.add_edge("pos", END)
+        graph.add_edge("neg", END)
+
+        self.assertEqual(graph.run(2), 3)
+        self.assertEqual(graph.run(-3), -4)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- implement a minimal `StateGraph` fallback
- expose langgraph stub automatically in tests
- add basic unit tests for node addition, edges and routing

## Testing
- `PYTHONPATH=legal_ai_system nose2 legal_ai_system.tests.test_stategraph_basic -v`
- `PYTHONPATH=legal_ai_system nose2 legal_ai_system.tests.test_langgraph_stub -v`
- `PYTHONPATH=legal_ai_system nose2 -v` *(fails: ModuleImportFailure and missing optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684ae31d8f0483239f0989032f18b84f