### PR TITLE
Mark stub modules for backlog

### DIFF
--- a/legal_ai_system/docs/stub_backlog.md
+++ b/legal_ai_system/docs/stub_backlog.md
@@ -1,0 +1,12 @@
+# Stub Backlog
+
+This backlog tracks stub modules that require full implementations. Each entry should be
+removed once the stub is replaced with production-ready code.
+
+| Module/Folder | Description | Status |
+|---------------|-------------|--------|
+| `legal_ai_database` | Simplified database utilities and in-memory preferences. | Pending |
+| `legal_ai_desktop` | Minimal PyQt6 GUI components for early prototypes. | Pending |
+| `legal_ai_network` | Placeholder networking layer used by the GUI. | Pending |
+| `legal_ai_widgets` | Demo widget collection for prototype UI elements. | Pending |
+| `legal_ai_charts` | Thin wrapper re-exporting chart widgets. | Pending |

--- a/legal_ai_system/legal_ai_charts/__init__.py
+++ b/legal_ai_system/legal_ai_charts/__init__.py
@@ -1,3 +1,4 @@
+# AGENT_STUB
 """Convenience re-exports for chart widgets."""
 
 from legal_ai_system.gui.widgets.legal_ai_charts import *

--- a/legal_ai_system/legal_ai_database/__init__.py
+++ b/legal_ai_system/legal_ai_database/__init__.py
@@ -1,3 +1,4 @@
+# AGENT_STUB
 """Simplified database utilities and preference storage."""
 from __future__ import annotations
 

--- a/legal_ai_system/legal_ai_desktop/__init__.py
+++ b/legal_ai_system/legal_ai_desktop/__init__.py
@@ -1,3 +1,4 @@
+# AGENT_STUB
 """Minimal desktop UI components for the integrated GUI."""
 from __future__ import annotations
 

--- a/legal_ai_system/legal_ai_network/__init__.py
+++ b/legal_ai_system/legal_ai_network/__init__.py
@@ -1,3 +1,4 @@
+# AGENT_STUB
 """Networking stubs for the integrated GUI."""
 from __future__ import annotations
 from pathlib import Path

--- a/legal_ai_system/legal_ai_widgets/__init__.py
+++ b/legal_ai_system/legal_ai_widgets/__init__.py
@@ -1,3 +1,4 @@
+# AGENT_STUB
 """Small collection of custom Qt widgets used by the GUI."""
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- add AGENT_STUB marker to stub packages
- track stub modules in docs/stub_backlog.md

## Testing
- `nose2 -v` *(fails: ModuleImportFailure)*

------
https://chatgpt.com/codex/tasks/task_e_684ae5cc25c48323a0edf9b1b958aec5