### PR TITLE
Add stub backlog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Diagnostic Tools: Actively use browser developer tools (console, network tab) to
 Detect & Report Gaps: If a frontend component needs dynamic data but lacks a backend API, or a UI action lacks a backend handler, immediately flag this as a missing component or incomplete integration.
 5. Manage Stubs Systematically
 Clear Marking: Every stub MUST be clearly marked with AGENT_STUB comments and added to an internal "Stub Backlog".
+See [docs/stub_backlog.md](docs/stub_backlog.md) for the current list of stubs and their planned replacements.
 Prioritized Implementation: Immediately prioritize and schedule implementation of critical path stubs, followed by dependency-blocking stubs.
 Full Implementation: For each stub, replace all dummy data and placeholder logic with robust, tested, and error-handled code.
 Remove Markers: Delete all AGENT_STUB markers and remove from backlog only upon full implementation and testing.

--- a/docs/stub_backlog.md
+++ b/docs/stub_backlog.md
@@ -1,0 +1,14 @@
+# Stub Backlog
+
+This backlog tracks all modules currently marked with `AGENT_STUB` comments. Each entry records the
+file path, a short description of its intended functionality, the date it was flagged, and the
+current status or plan for implementation. Update this list whenever a stub is added or removed.
+
+| File Path | Description | Date Flagged | Status/Plan |
+|-----------|-------------|--------------|-------------|
+| `legal_ai_system/legal_ai_network/__init__.py` | Networking stubs for the integrated GUI. | 2025-06-12 | Replace with asynchronous API client and WebSocket implementation. |
+| `legal_ai_system/legal_ai_database/__init__.py` | Simplified database utilities and preferences storage. | 2025-06-12 | Implement production database layer with caching and persistence. |
+| `legal_ai_system/legal_ai_desktop/__init__.py` | Minimal PyQt6 desktop UI components for early prototypes. | 2025-06-12 | Remove once features are migrated to the main GUI. |
+| `legal_ai_system/legal_ai_widgets/__init__.py` | Demo widget collection for prototype UI elements. | 2025-06-12 | Integrate useful widgets into `gui/widgets` and delete the rest. |
+| `legal_ai_system/legal_ai_charts/__init__.py` | Thin wrapper re-exporting chart widgets. | 2025-06-12 | Replace with direct imports after chart modules are finalized. |
+


### PR DESCRIPTION
## Summary
- document stubbed modules in `docs/stub_backlog.md`
- link the backlog from `AGENTS.md`

## Testing
- `nose2 -v` *(fails: ModuleImportFailure)*

------
https://chatgpt.com/codex/tasks/task_e_684ae779f4488323a8829c14a418464d