### PR TITLE
Flag unused maintenance scripts

### DIFF
--- a/legal_ai_system/docs/file_audit.md
+++ b/legal_ai_system/docs/file_audit.md
@@ -165,6 +165,11 @@ The following packages are mostly stubs and were previously flagged in `cleanup_
 
 These modules contain minimal code and are primarily re-export or placeholder implementations. They can likely be removed or consolidated once the PyQt6 GUI (`legal_ai_system/gui/legal_ai_pyqt6_integrated.py`) is fully adopted.
 
+Additionally, the following scripts are not referenced in the documentation or CI workflows and appear unused:
+
+- `legal_ai_system/scripts/migrate_database.py`
+- `legal_ai_system/scripts/start_linkage_check.py`
+
 ## Documentation Review
 
 The following documentation files reference modules or behaviour that no longer


### PR DESCRIPTION
## Summary
- mark migrate_database.py and start_linkage_check.py as unused in documentation

## Testing
- `nose2 -v` *(fails: ImportError and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684aeaf17a7483239f4d543b9ef78819