### PR TITLE
Add Postgres downtime guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,3 +186,7 @@ The audit report in
 [legal_ai_system/docs/file_audit.md](legal_ai_system/docs/file_audit.md)
 captures the current folder layout, dependency findings, and a cleanup plan.
 Refer to it when making structural changes or removing deprecated modules.
+
+If PostgreSQL becomes unavailable, the application enters a degraded mode.
+Refer to [legal_ai_system/docs/postgres_downtime_impact.md](legal_ai_system/docs/postgres_downtime_impact.md)
+for a detailed list of features that are disabled or limited during downtime.

--- a/legal_ai_system/docs/postgres_downtime_impact.md
+++ b/legal_ai_system/docs/postgres_downtime_impact.md
@@ -1,0 +1,50 @@
+# PostgreSQL Downtime Impact
+
+The system is designed to gracefully degrade when the PostgreSQL service is unavailable. This document outlines what functionality is affected and what remains operational.
+
+## Completely Unavailable
+
+- **User Authentication & Security**
+  - Login/logout
+  - Session persistence
+  - Access control
+  - Audit logging
+- **Knowledge Management**
+  - Entity extraction storage
+  - Relationship mapping
+  - Knowledge graph
+  - Cross-document linking
+- **Advanced Search & AI**
+  - Vector metadata
+  - Content deduplication
+  - Search optimization
+  - Enhanced search results
+- **Workflow Management**
+  - Workflow persistence
+  - Progress tracking
+  - Batch processing
+
+## Degraded Features
+
+- **Document Processing**
+  - Text extraction works
+  - AI analysis works
+  - Cannot save results persistently
+  - No processing status tracking
+- **Search**
+  - Basic FAISS vector search works
+  - No metadata enhancement
+  - No search history
+
+## Fully Functional (SQLite-based)
+
+- Core document processing
+- Local memory storage
+- Basic GUI
+- FAISS vector operations
+- Local database for violation tracking
+
+## User Experience Impact
+
+With PostgreSQL offline the application behaves like a single-user session-based tool. Documents can still be processed and analysed, but persistent knowledge management and multi-user collaboration are not available.
+


### PR DESCRIPTION
## Summary
- document degraded features when PostgreSQL is unavailable
- link the downtime guide from the README

## Testing
- `nose2 -s legal_ai_system/tests` *(fails: ImportError: cannot import name 'Field' from 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684af09403048323a6743d996d6960b1