### PR TITLE
Implement dynamic agent registration and integration map

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ See the documents in the `legal_ai_system/docs/` folder for architecture details
 usage. The [Integration Guide](legal_ai_system/docs/integration_plan.md) summarises the
 five-phase integration plan, WebSocket patterns and deployment tips and
 includes sections on security, testing, success metrics and troubleshooting.
+For a high level diagram showing how services, agents and workflows connect, see
+[docs/integration_map.md](docs/integration_map.md).
 
 The audit report in
 [legal_ai_system/docs/file_audit.md](legal_ai_system/docs/file_audit.md)

--- a/docs/integration_map.md
+++ b/docs/integration_map.md
@@ -1,0 +1,36 @@
+# Integration Map
+
+This document summarizes how the main components of the Legal AI System fit together.
+It complements `legal_ai_system/docs/system_layout.md` but focuses on the high level
+relationships between services, agents, workflows and the GUI/API entry points.
+
+## Core Layers
+
+1. **Service Container** – created by `create_service_container()`.
+   It registers and initializes all services and agents.  Services include
+   persistence, vector stores, analytics, and workflow orchestration.
+2. **Agents** – dynamically registered from `legal_ai_system/agents` via
+   the service container.  Each agent can be fetched by name from the container
+   and used within workflows.
+3. **Workflow Engine** – `WorkflowOrchestrator` obtains agents and managers
+   from the container to run document processing pipelines such as
+   `RealTimeAnalysisWorkflow`.
+4. **API & GUI** – the FastAPI backend and the PyQt6 GUI use the
+   `LegalAIIntegrationService` which itself relies on the container.  The
+   GUI connects through `BackendBridge` so user actions trigger backend workflows.
+5. **Analytics & Quality** – `KeywordExtractionService` and
+   `QualityAssessmentService` provide metrics for dashboards and automated
+   quality checks.
+
+## Data Flow
+
+1. Documents are uploaded via the API or GUI.
+2. The integration service saves the file using the persistence layer and
+   triggers a workflow through the orchestrator.
+3. Workflows invoke agents in sequence; each agent may read or update
+   data in the vector store, memory manager or knowledge graph services.
+4. Progress updates are emitted back through the integration service to
+   the frontend (GUI or REST clients).
+
+This map should help new developers understand which modules interact and
+where to extend the system for new services or agents.

--- a/legal_ai_system/services/service_container.py
+++ b/legal_ai_system/services/service_container.py
@@ -545,6 +545,47 @@ def create_persistence_manager(
     )
 
 
+async def register_all_agents(
+    container: "ServiceContainer", config_manager_service: Any
+) -> None:
+    """Discover agents under ``legal_ai_system/agents`` and register them.
+
+    Modules are not imported until the agent instance is requested to avoid
+    heavy imports during container setup.  Each agent is registered under a
+    lowercase key derived from the class name.
+    """
+    import ast
+    from importlib import import_module
+    from pathlib import Path
+
+    agents_path = Path(__file__).resolve().parents[1] / "agents"
+    for file in agents_path.glob("*.py"):
+        module_name = f"legal_ai_system.agents.{file.stem}"
+        with open(file, "r", encoding="utf-8") as fh:
+            tree = ast.parse(fh.read(), filename=str(file))
+
+        class_names = [
+            n.name
+            for n in tree.body
+            if isinstance(n, ast.ClassDef)
+            and (n.name.endswith("Agent") or n.name.endswith("Engine"))
+        ]
+        for cls_name in class_names:
+            agent_id = cls_name.lower()
+            agent_config = config_manager_service.get(
+                f"agents.{agent_id}_config", {}
+            )
+
+            async def factory(sc, *, m=module_name, c=cls_name, cfg=agent_config):
+                mod = import_module(m)
+                cls = getattr(mod, c)
+                return cls(sc, **cfg)
+
+            await container.register_service(
+                agent_id, factory=factory, is_async_factory=True
+            )
+
+
 # Global factory function to create and populate the service container
 # This is where you define how your system's services are created and wired together.
 async def create_service_container(
@@ -891,93 +932,9 @@ async def create_service_container(
         is_async_factory=False,
     )
 
-    # Agents are often stateful per task, so factories are common.
-    # Or, if stateless, can be singletons. BaseAgent is typically instantiated per use or task.
-    # Here we register the classes themselves, and workflows will instantiate them.
-    # If agents are true "services" (long-lived, shared), then register instances.
-    # For now, let's assume workflows will get agent *classes* or factories.
-    # Or, if agents are simple enough to be singletons:
-    from ..agents.document_processor_agent import DocumentProcessorAgent
-    from ..agents.document_processor_agent_v2 import DocumentProcessorAgentV2
-    from ..agents.document_rewriter_agent import DocumentRewriterAgent
-    from ..agents.ontology_extraction_agent import OntologyExtractionAgent
-    from ..agents.entity_extraction_agent import StreamlinedEntityExtractionAgent
-    from ..agents.legal_reasoning_engine import LegalReasoningEngine
-    from ..agents.knowledge_graph_reasoning_agent import (
-        KnowledgeGraphReasoningAgent,
-    )
-
-    # Example: await container.register_service("document_processor_agent", instance=DocumentProcessorAgent(container))
-    # This needs careful thought: are agents services or instantiated by workflows?
-    # The original code often had agents take 'services' in __init__, implying they are created with access to container.
-    # Let's register them as factories that take the container.
-
-    agent_classes = {
-        "document_processor_agent": DocumentProcessorAgent,
-        "document_processor_agent_v2": DocumentProcessorAgentV2,
-        "ontology_extraction_agent": OntologyExtractionAgent,
-        "streamlined_entity_extraction_agent": StreamlinedEntityExtractionAgent,
-        # ... Add all other agent classes from agents/__init__.py
-        "semantic_analysis_agent": getattr(
-            __import__("legal_ai_system.agents", fromlist=["SemanticAnalysisAgent"]),
-            "SemanticAnalysisAgent",
-            None,
-        ),
-        "structural_analysis_agent": getattr(
-            __import__("legal_ai_system.agents", fromlist=["StructuralAnalysisAgent"]),
-            "StructuralAnalysisAgent",
-            None,
-        ),
-        "citation_analysis_agent": getattr(
-            __import__("legal_ai_system.agents", fromlist=["CitationAnalysisAgent"]),
-            "CitationAnalysisAgent",
-            None,
-        ),
-        "text_correction_agent": getattr(
-            __import__("legal_ai_system.agents", fromlist=["TextCorrectionAgent"]),
-            "TextCorrectionAgent",
-            None,
-        ),
-        "document_rewriter_agent": DocumentRewriterAgent,
-        "violation_detector_agent": getattr(
-            __import__("legal_ai_system.agents", fromlist=["ViolationDetectorAgent"]),
-            "ViolationDetectorAgent",
-            None,
-        ),
-        "auto_tagging_agent": getattr(
-            __import__("legal_ai_system.agents", fromlist=["AutoTaggingAgent"]),
-            "AutoTaggingAgent",
-            None,
-        ),
-        "note_taking_agent": getattr(
-            __import__("legal_ai_system.agents", fromlist=["NoteTakingAgent"]),
-            "NoteTakingAgent",
-            None,
-        ),
-        "legal_analysis_agent": getattr(
-            __import__("legal_ai_system.agents", fromlist=["LegalAnalysisAgent"]),
-            "LegalAnalysisAgent",
-            None,
-        ),
-        "knowledge_base_agent": getattr(
-            __import__("legal_ai_system.agents", fromlist=["KnowledgeBaseAgent"]),
-            "KnowledgeBaseAgent",
-            None,
-        ),
-        "knowledge_graph_reasoning_agent": KnowledgeGraphReasoningAgent,
-        "legal_reasoning_engine": LegalReasoningEngine,
-    }
-    for name, agent_cls in agent_classes.items():
-        if agent_cls:  # Check if import was successful
-            agent_config = config_manager_service.get(
-                f"agents.{name}_config", {}
-            )  # Agent specific config
-            # Pass the service_container (self) to the factory
-            await container.register_service(
-                name,
-                factory=lambda sc, cfg=agent_config, cls=agent_cls: cls(sc, **cfg),
-                is_async_factory=False,
-            )
+    # Dynamically register all available agents. This defers module imports
+    # until the agent is actually requested from the container.
+    await register_all_agents(container, config_manager_service)
 
     # Register simple LangGraph node classes for builder workflows
     from ..agents.agent_nodes import AnalysisNode, SummaryNode

--- a/legal_ai_system/tests/test_dynamic_agent_registration.py
+++ b/legal_ai_system/tests/test_dynamic_agent_registration.py
@@ -1,0 +1,16 @@
+import unittest
+
+from legal_ai_system.services.service_container import ServiceContainer, register_all_agents
+
+
+class DummyConfig:
+    def get(self, key, default=None):
+        return {}
+
+
+class TestDynamicAgentRegistration(unittest.IsolatedAsyncioTestCase):
+    async def test_register_all_agents_discovers_agents(self) -> None:
+        container = ServiceContainer()
+        await register_all_agents(container, DummyConfig())
+        self.assertIn("legalreasoningengine", container._service_factories)
+        self.assertTrue(container._service_factories["legalreasoningengine"]["is_async"])


### PR DESCRIPTION
## Summary
- add integration_map documentation
- register all agents lazily via new helper
- reference the integration map in the README
- add unit test verifying agent discovery

## Testing
- `nose2 -v legal_ai_system.tests.test_dynamic_agent_registration`

------
https://chatgpt.com/codex/tasks/task_e_684af9dbe5f48323a059a908af894b5d