### PR TITLE
Implement DocumentRewriterAgent in real-time workflow

### DIFF
--- a/legal_ai_system/docs/system_layout.md
+++ b/legal_ai_system/docs/system_layout.md
@@ -78,7 +78,7 @@ Key services registered with the container include:
 
 ## Workflows and Connections
 
-`RealTimeAnalysisWorkflow` assembles several agents and managers to process a document.  Its constructor creates a `DocumentProcessorAgent`, `DocumentRewriterAgent`, `OntologyExtractionAgent`, `HybridLegalExtractor`, `RealTimeGraphManager`, `EnhancedVectorStore` and `ReviewableMemory`.  Source: `services/realtime_analysis_workflow.py` lines 92‑109.  The workflow coordinates extraction, enrichment, and persistence in a single asynchronous pipeline.
+`RealTimeAnalysisWorkflow` assembles several agents and managers to process a document.  Its constructor creates a `DocumentProcessorAgent`, `DocumentRewriterAgent`, `OntologyExtractionAgent`, `HybridLegalExtractor`, `RealTimeGraphManager`, `EnhancedVectorStore` and `ReviewableMemory`.  Source: `services/realtime_analysis_workflow.py` lines 90‑170.  The workflow coordinates extraction, enrichment, and persistence in a single asynchronous pipeline.
 
 During processing:
 

--- a/legal_ai_system/tests/test_case_workflow_state.py
+++ b/legal_ai_system/tests/test_case_workflow_state.py
@@ -86,6 +86,7 @@ class StubResult:
     document_id: str
     processing_times: dict = field(default_factory=dict)
     total_processing_time: float = 0.0
+    text_rewriting: dict = field(default_factory=dict)
     confidence_scores: dict = field(default_factory=dict)
     validation_results: dict = field(default_factory=dict)
     sync_status: dict = field(default_factory=dict)

--- a/legal_ai_system/tests/test_realtime_workflow_refactor.py
+++ b/legal_ai_system/tests/test_realtime_workflow_refactor.py
@@ -150,6 +150,7 @@ async def test_process_document_realtime_returns_result_structure() -> None:
         "graph_updates",
         "vector_updates",
         "memory_updates",
+        "text_rewriting",
     }
     assert expected_keys.issubset(set(data.keys()))
     assert result.document_id
@@ -172,6 +173,14 @@ async def test_process_document_realtime_updates_graph_and_vectors() -> None:
 
     wf._update_knowledge_graph_realtime.assert_awaited()
     wf._update_vector_store_realtime.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_document_realtime_invokes_rewriter() -> None:
+    wf = DummyWorkflow()
+    await wf.process_document_realtime("sample.txt")
+
+    wf.document_rewriter.rewrite_text.assert_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- instantiate core agents from the service container when creating `RealTimeAnalysisWorkflow`
- include a text rewriting step using `DocumentRewriterAgent`
- record rewrite results in `RealTimeAnalysisResult`
- update docs and unit tests for the new step

## Testing
- `PYTHONPATH=. nose2 -s legal_ai_system/tests -v` *(fails: ModuleNotFoundError for missing optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684b04e425708323a679a31c2b8af912