### PR TITLE
Add disk persistence for cache

### DIFF
--- a/legal_ai_system/core/enhanced_persistence.py
+++ b/legal_ai_system/core/enhanced_persistence.py
@@ -8,6 +8,7 @@
 import asyncio
 import asyncpg # For PostgreSQL
 import aioredis # For Redis
+import aiofiles
 from typing import Any, Dict, List, Optional, Union, AsyncGenerator
 from dataclasses import dataclass, asdict, field # Added field
 from datetime import datetime, timezone # Added timezone
@@ -892,6 +893,53 @@ class CacheManager:
         except Exception as e:
             self.logger.error("Unexpected error fetching cache stats.", exception=e)
             return {"error": f"Unexpected error: {str(e)}"}
+
+    @detailed_log_function(LogCategory.DATABASE)
+    async def persist_to_disk(self, file_path: str) -> bool:
+        """Persist all cached values to a JSON file for durability."""
+        if not self.pool.redis_pool:
+            self.logger.warning("Redis pool not initialized, cannot persist cache.")
+            return False
+        try:
+            async with self.pool.get_redis_connection() as redis:
+                keys = await redis.keys("*")
+                data: Dict[str, Any] = {}
+                for key in keys:
+                    val = await redis.get(key)
+                    if val is not None:
+                        try:
+                            data[key.decode("utf-8") if isinstance(key, bytes) else key] = json.loads(val.decode("utf-8"))
+                        except Exception:
+                            continue
+            async with aiofiles.open(file_path, "w") as f:
+                await f.write(json.dumps(data))
+            self.logger.info("Cache persisted to disk.", parameters={"file": file_path, "entries": len(data)})
+            return True
+        except Exception as e:
+            self.logger.error("Failed to persist cache to disk.", parameters={"file": file_path}, exception=e)
+            return False
+
+    @detailed_log_function(LogCategory.DATABASE)
+    async def load_from_disk(self, file_path: str) -> int:
+        """Load cached values from a JSON file. Returns number of entries restored."""
+        if not self.pool.redis_pool:
+            self.logger.warning("Redis pool not initialized, cannot load cache.")
+            return 0
+        try:
+            async with aiofiles.open(file_path, "r") as f:
+                content = await f.read()
+            data = json.loads(content)
+            async with self.pool.get_redis_connection() as redis:
+                for key, value in data.items():
+                    await redis.set(key, json.dumps(value))
+            self.logger.info("Cache loaded from disk.", parameters={"file": file_path, "entries": len(data)})
+            return len(data)
+        except FileNotFoundError:
+            self.logger.warning("Cache file not found during load.", parameters={"file": file_path})
+            return 0
+        except Exception as e:
+            self.logger.error("Failed to load cache from disk.", parameters={"file": file_path}, exception=e)
+            return 0
 
 
 class EnhancedPersistenceManager:

--- a/legal_ai_system/tests/test_cache_manager_persistence.py
+++ b/legal_ai_system/tests/test_cache_manager_persistence.py
@@ -1,0 +1,67 @@
+from contextlib import asynccontextmanager
+
+import pytest
+import fakeredis.aioredis
+
+import sys
+from types import ModuleType
+
+pyd = ModuleType("pydantic")
+pyd.BaseModel = object
+pyd.BaseSettings = object
+def _field(default=None, **kwargs):
+    return default
+pyd.Field = _field
+sys.modules.setdefault("pydantic", pyd)
+if "asyncpg" not in sys.modules:
+    asyncpg_mod = ModuleType("asyncpg")
+    asyncpg_mod.Connection = object
+    sys.modules["asyncpg"] = asyncpg_mod
+if "aioredis" not in sys.modules:
+    aioredis_mod = ModuleType("aioredis")
+    exc = ModuleType("exceptions")
+    exc.RedisError = type("RedisError", (Exception,), {})
+    aioredis_mod.Redis = object
+    aioredis_mod.exceptions = exc
+    sys.modules["aioredis"] = aioredis_mod
+if "aiofiles" not in sys.modules:
+    aiofiles_mod = ModuleType("aiofiles")
+    class _AsyncFile:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def read(self):
+            return "{}"
+        async def write(self, _):
+            pass
+    async def open(*a, **k):
+        return _AsyncFile()
+    aiofiles_mod.open = open
+    sys.modules["aiofiles"] = aiofiles_mod
+
+from legal_ai_system.core.enhanced_persistence import CacheManager
+
+class FakePool:
+    def __init__(self):
+        self.redis = fakeredis.aioredis.FakeRedis()
+        self.redis_pool = self.redis
+
+    @asynccontextmanager
+    async def get_redis_connection(self):
+        yield self.redis
+
+@pytest.mark.asyncio
+async def test_cache_persist_and_load(tmp_path):
+    pool = FakePool()
+    cm = CacheManager(pool, default_ttl_seconds=60)
+    await cm.set("alpha", {"x": 1})
+    cache_file = tmp_path / "cache.json"
+    saved = await cm.persist_to_disk(str(cache_file))
+    assert saved is True
+    await cm.delete("alpha")
+    assert await cm.get("alpha") is None
+    loaded = await cm.load_from_disk(str(cache_file))
+    assert loaded == 1
+    value = await cm.get("alpha")
+    assert value == {"x": 1}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,3 +29,4 @@ numpy>=1.24.0
 PyYAML>=6.0
 typer>=0.9.0
 joblib>=1.3.0
+fakeredis>=2.29.0


### PR DESCRIPTION
## Summary
- extend CacheManager with ability to persist cache data to JSON files
- include fakeredis in dev dependencies
- add regression test for cache persistence

## Testing
- `PYTHONPATH=. nose2 -s legal_ai_system/tests`


------
https://chatgpt.com/codex/tasks/task_e_684b3ee55e708323b79ebe36e403b786