### PR TITLE
Add agent categories

### DIFF
--- a/legal_ai_system/agents/__init__.py
+++ b/legal_ai_system/agents/__init__.py
@@ -1,0 +1,56 @@
+"""Agent package initialization with logical categories."""
+
+from .semantic_analysis_agent import SemanticAnalysisAgent
+from .structural_analysis_agent import StructuralAnalysisAgent
+from .citation_analysis_agent import CitationAnalysisAgent
+from .legal_analysis_agent import LegalAnalysisAgent
+from .document_processor_agent import DocumentProcessorAgent
+from .document_processor_agent_v2 import DocumentProcessorAgentV2
+from .document_rewriter_agent import DocumentRewriterAgent
+from .text_correction_agent import TextCorrectionAgent
+from .knowledge_base_agent import KnowledgeBaseAgent
+from .knowledge_graph_reasoning_agent import KnowledgeGraphReasoningAgent
+from .legal_reasoning_engine import LegalReasoningEngine
+from .graph_inference_agent import GraphInferenceAgent
+from .precedent_matching_agent import PrecedentMatchingAgent
+from .entity_extraction_agent import StreamlinedEntityExtractionAgent
+from .ontology_extraction_agent import OntologyExtractionAgent
+from .auto_tagging_agent import AutoTaggingAgent
+from .violation_detector_agent import ViolationDetectorAgent
+from .note_taking_agent import NoteTakingAgent
+
+# Mapping of agent categories to lists of agent classes for easier introspection
+# and registration. Importing here keeps all agents discoverable from a single
+# location without altering the existing dynamic loader in the service container.
+AGENT_CATEGORIES = {
+    "analysis": [
+        SemanticAnalysisAgent,
+        StructuralAnalysisAgent,
+        CitationAnalysisAgent,
+        LegalAnalysisAgent,
+    ],
+    "document_processing": [
+        DocumentProcessorAgent,
+        DocumentProcessorAgentV2,
+        DocumentRewriterAgent,
+        TextCorrectionAgent,
+    ],
+    "knowledge_reasoning": [
+        KnowledgeBaseAgent,
+        KnowledgeGraphReasoningAgent,
+        LegalReasoningEngine,
+        GraphInferenceAgent,
+        PrecedentMatchingAgent,
+    ],
+    "extraction_classification": [
+        StreamlinedEntityExtractionAgent,
+        OntologyExtractionAgent,
+        AutoTaggingAgent,
+        ViolationDetectorAgent,
+    ],
+    "utility": [
+        NoteTakingAgent,
+    ],
+}
+
+__all__ = ["AGENT_CATEGORIES"]

--- a/legal_ai_system/docs/agent_categories.md
+++ b/legal_ai_system/docs/agent_categories.md
@@ -1,0 +1,33 @@
+# Agent Categories
+
+The Legal AI System organizes its agents into logical categories. This overview helps developers quickly locate and register the correct components when extending workflows or the GUI.
+
+## Analysis Agents
+- `SemanticAnalysisAgent`
+- `StructuralAnalysisAgent`
+- `CitationAnalysisAgent`
+- `LegalAnalysisAgent`
+
+## Document Processing
+- `DocumentProcessorAgent`
+- `DocumentProcessorAgentV2`
+- `DocumentRewriterAgent`
+- `TextCorrectionAgent`
+
+## Knowledge & Reasoning
+- `KnowledgeBaseAgent`
+- `KnowledgeGraphReasoningAgent`
+- `LegalReasoningEngine`
+- `GraphInferenceAgent`
+- `PrecedentMatchingAgent`
+
+## Extraction & Classification
+- `StreamlinedEntityExtractionAgent`
+- `OntologyExtractionAgent`
+- `AutoTaggingAgent`
+- `ViolationDetectorAgent`
+
+## Utility
+- `NoteTakingAgent`
+
+These groupings match the `AGENT_CATEGORIES` mapping defined in `legal_ai_system/agents/__init__.py` and make it easier to understand how the system's capabilities are structured.


### PR DESCRIPTION
## Summary
- organize agents into logical categories by adding `AGENT_CATEGORIES` mapping
- document the categories for quick reference

## Testing
- `nose2 -v legal_ai_system.tests.test_auto_tagging_learning_stats` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684b3f379c848323852fa2cde97c9dca