### PR TITLE
Add AgentManagerWidget and AI Agents tab

### DIFF
--- a/legal_ai_system/gui/legal_ai_pyqt6_integrated.py
+++ b/legal_ai_system/gui/legal_ai_pyqt6_integrated.py
@@ -20,6 +20,7 @@ from legal_ai_system.gui.widgets.legal_ai_charts import (
     ChartData,
     AnalyticsDashboardWidget,
 )
+from legal_ai_system.gui.widgets.agent_manager_widget import AgentManagerWidget
 from legal_ai_system.legal_ai_network import (
     NetworkManager,
     LegalAIAPIClient,
@@ -357,6 +358,10 @@ class IntegratedMainWindow(QMainWindow):
         # Processing Queue tab
         self.queue_widget = self.createQueueView()
         self.main_tabs.addTab(self.queue_widget, "Processing Queue")
+
+        # AI Agents tab
+        self.agent_manager = AgentManagerWidget()
+        self.main_tabs.addTab(self.agent_manager, "AI Agents")
         
         main_layout.addWidget(self.main_tabs)
         

--- a/legal_ai_system/gui/widgets/__init__.py
+++ b/legal_ai_system/gui/widgets/__init__.py
@@ -5,10 +5,12 @@ from .legal_ai_charts import (
     PieChartWidget,
     BarChartWidget,
 )
+from .agent_manager_widget import AgentManagerWidget
 
 __all__ = [
     "AnalyticsDashboardWidget",
     "PieChartWidget",
     "BarChartWidget",
+    "AgentManagerWidget",
 ]
 

--- a/legal_ai_system/gui/widgets/agent_manager_widget.py
+++ b/legal_ai_system/gui/widgets/agent_manager_widget.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from PyQt6.QtCore import Qt, QTimer
+from PyQt6.QtWidgets import (
+    QWidget,
+    QTabWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QPushButton,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QDialog,
+    QFormLayout,
+    QLineEdit,
+    QDialogButtonBox,
+)
+
+
+class AgentSettingsDialog(QDialog):
+    """Simple settings dialog for configuring an agent."""
+
+    def __init__(self, agent_name: str, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle(f"{agent_name} Settings")
+        layout = QFormLayout(self)
+        self.endpoint_edit = QLineEdit()
+        layout.addRow("API Endpoint", self.endpoint_edit)
+        self.token_edit = QLineEdit()
+        layout.addRow("Token", self.token_edit)
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+
+class AgentCategoryTab(QWidget):
+    """Tab widget containing controls and queue for an agent category."""
+
+    def __init__(self, title: str, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.title = title
+        layout = QVBoxLayout(self)
+
+        control_bar = QWidget()
+        control_layout = QHBoxLayout(control_bar)
+        self.start_btn = QPushButton("Start All")
+        self.stop_btn = QPushButton("Stop All")
+        self.settings_btn = QPushButton("Settings")
+        self.settings_btn.clicked.connect(self.open_settings)
+        control_layout.addWidget(self.start_btn)
+        control_layout.addWidget(self.stop_btn)
+        control_layout.addStretch()
+        control_layout.addWidget(self.settings_btn)
+        layout.addWidget(control_bar)
+
+        self.queue = QTreeWidget()
+        self.queue.setHeaderLabels(["Task", "Status", "Progress"])
+        layout.addWidget(self.queue)
+
+        self.monitor = QTimer(self)
+        self.monitor.timeout.connect(self.update_progress)
+        self.monitor.start(1000)
+
+    def open_settings(self) -> None:  # pragma: no cover - GUI logic
+        dlg = AgentSettingsDialog(self.title, self)
+        dlg.exec()
+
+    def add_task(self, task_name: str) -> QTreeWidgetItem:
+        item = QTreeWidgetItem([task_name, "Pending", "0%"])
+        self.queue.addTopLevelItem(item)
+        return item
+
+    def update_task_progress(self, item: QTreeWidgetItem, progress: int) -> None:
+        item.setText(1, "Running" if progress < 100 else "Done")
+        item.setText(2, f"{progress}%")
+
+    def update_progress(self) -> None:  # pragma: no cover - placeholder
+        # Real monitoring would pull task states from backend
+        pass
+
+
+class AgentManagerWidget(QWidget):
+    """Central widget managing all AI agents."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        self.tabs = QTabWidget()
+        layout.addWidget(self.tabs)
+
+        self.categories: Dict[str, AgentCategoryTab] = {}
+        self._create_default_tabs()
+
+    def _create_default_tabs(self) -> None:
+        self.add_category("Document Agents")
+        self.add_category("Analysis Agents")
+        self.add_category("Utilities")
+
+    def add_category(self, name: str) -> AgentCategoryTab:
+        tab = AgentCategoryTab(name)
+        self.tabs.addTab(tab, name)
+        self.categories[name] = tab
+        return tab
+
+    def add_task(self, category: str, task_name: str) -> Optional[QTreeWidgetItem]:
+        tab = self.categories.get(category)
+        if tab:
+            return tab.add_task(task_name)
+        return None
+
+


### PR DESCRIPTION
## Summary
- add `AgentManagerWidget` with agent tabs and queue
- export new widget in GUI package
- integrate AI Agents tab into main application window

## Testing
- `nose2 -v` *(fails: ModuleImportFailure, missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684b3f3cdeb88323a92e0d8e7e232818