### PR TITLE
Integrate memory manager and DB logging

### DIFF
--- a/legal_ai_system/services/service_container.py
+++ b/legal_ai_system/services/service_container.py
@@ -632,6 +632,13 @@ async def create_service_container(
 
     connection_pool_service = await container.get_service("connection_pool")
 
+    from .database_manager import DatabaseManager
+    db_path = str(config_manager_service.get("data_dir") / "databases" / "legal_ai_gui.db")
+    await container.register_service(
+        "database_manager",
+        instance=DatabaseManager(db_path),
+    )
+
     # 3. Persistence Manager
     persistence_cfg = config_manager_service.get("persistence_layer_details", {})
     await container.register_service(


### PR DESCRIPTION
## Summary
- log agent results to unified memory manager and new DB table
- store agent results persistently via `DatabaseManager`
- register `database_manager` within service container

## Testing
- `nose2 -v` *(fails: ImportError: PyQt6 etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684b3f4a53648323a0cd4319d5bf62d5