### PR TITLE
Implement workflow update broadcast

### DIFF
--- a/legal_ai_system/tests/test_realtime_workflow_refactor.py
+++ b/legal_ai_system/tests/test_realtime_workflow_refactor.py
@@ -18,9 +18,28 @@ for name in [
     "sklearn",
     "sklearn.metrics",
     "sklearn.metrics.pairwise",
+    "sklearn.feature_extraction.text",
+    "sklearn.linear_model",
+    "pydantic",
+    "fastapi",
+    "prometheus_client",
+    "uvicorn",
 ]:
     if name not in sys.modules:
         sys.modules[name] = ModuleType(name)
+    if name == "pydantic":
+        sys.modules[name].BaseModel = object
+        sys.modules[name].BaseSettings = object
+        sys.modules[name].Field = lambda *a, **k: k.get("default") if "default" in k else (a[0] if a else None)
+    if name == "fastapi":
+        sys.modules[name].FastAPI = object
+    if name == "prometheus_client":
+        sys.modules[name].Counter = lambda *a, **k: object()
+        sys.modules[name].Histogram = lambda *a, **k: object()
+        sys.modules[name].Gauge = lambda *a, **k: object()
+        sys.modules[name].make_asgi_app = lambda *a, **k: None
+    if name == "uvicorn":
+        sys.modules[name].run = lambda *a, **k: None
 
 class _RedisError(Exception):
     pass
@@ -32,6 +51,12 @@ exc.RedisError = _RedisError
 exc.TimeoutError = TimeoutError = type("TimeoutError", (Exception,), {})
 sys.modules["aioredis.exceptions"] = exc
 sys.modules["sklearn.metrics.pairwise"].cosine_similarity = lambda *a, **k: []
+sys.modules.setdefault("sklearn.feature_extraction", ModuleType("sklearn.feature_extraction"))
+sys.modules["sklearn.feature_extraction"].text = ModuleType("text")
+sys.modules["sklearn.feature_extraction"].text.TfidfVectorizer = object
+sys.modules["sklearn.feature_extraction.text"] = sys.modules["sklearn.feature_extraction"].text
+sys.modules.setdefault("sklearn.linear_model", ModuleType("sklearn.linear_model"))
+sys.modules["sklearn.linear_model"].LogisticRegression = object
 if not hasattr(sys.modules["numpy"], "array"):
     sys.modules["numpy"].array = lambda *a, **k: a
 if not hasattr(sys.modules["numpy"], "ndarray"):
@@ -194,6 +219,28 @@ async def test_process_document_realtime_queues_job_when_queue_available() -> No
     assert result == "job"
     queue.enqueue.assert_called_once()
     wf._notify_progress.assert_awaited_with("queued", 0.0)
+
+
+@pytest.mark.asyncio
+async def test_process_document_realtime_emits_completion_update() -> None:
+    wf = DummyWorkflow()
+    await wf.process_document_realtime("sample.txt")
+
+    wf._notify_update.assert_any_await(
+        "workflow_completed", pytest.ANY
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_document_realtime_emits_failure_update() -> None:
+    wf = DummyWorkflow()
+    wf._run_realtime_pipeline = AsyncMock(side_effect=RuntimeError("boom"))
+    with pytest.raises(RuntimeError):
+        await wf.process_document_realtime("sample.txt")
+
+    wf._notify_update.assert_any_await(
+        "workflow_failed", pytest.ANY
+    )
 
 
 


### PR DESCRIPTION
## Summary
- broadcast workflow progress and update events using `ConnectionManager`
- send workflow queued/completed/failed events from realtime workflow
- verify events in realtime workflow tests

## Testing
- `nose2 -v legal_ai_system.tests.test_realtime_workflow_refactor`
- `nose2 -v` *(fails: ModuleImportFailure errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b3f51ec2c8323af76d7eae5d78e63