### PR TITLE
Add GUI database connection dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,11 @@ features of the Streamlit and React frontends.
 It now includes an experimental **Agent Management** tab for viewing registered
 agents. Real‑time metrics and control actions require a future backend API.
 
+To connect the GUI to a remote PostgreSQL instance, open **Database Connections**
+from the *Settings* menu. The dialog stores the host, port, user, password and
+database name using ``QSettings`` and updates ``DATABASE_URL`` for the running
+session.
+
 The asynchronous network and database layers have been consolidated into the
 application itself, so document uploads and preference storage no longer rely on
 stub modules. Metrics can be streamed to connected clients by enabling the

--- a/legal_ai_system/gui/db_connection_dialog.py
+++ b/legal_ai_system/gui/db_connection_dialog.py
@@ -13,6 +13,7 @@ from typing import Iterable
 
 from PyQt6.QtCore import QSettings
 from PyQt6.QtWidgets import (
+    QComboBox,
     QDialog,
     QDialogButtonBox,
     QFormLayout,
@@ -38,15 +39,20 @@ class DBConnectionDialog(QDialog):
         main_layout.addWidget(self.available_list)
 
         form_layout = QFormLayout()
+        self.db_type_combo = QComboBox()
+        self.db_type_combo.addItems(["PostgreSQL", "SQLite"])
+        form_layout.addRow("Type:", self.db_type_combo)
         self.host_edit = QLineEdit()
         self.port_edit = QLineEdit()
         self.user_edit = QLineEdit()
         self.password_edit = QLineEdit()
         self.password_edit.setEchoMode(QLineEdit.EchoMode.Password)
+        self.db_name_edit = QLineEdit()
         form_layout.addRow("Host:", self.host_edit)
         form_layout.addRow("Port:", self.port_edit)
         form_layout.addRow("User:", self.user_edit)
         form_layout.addRow("Password:", self.password_edit)
+        form_layout.addRow("Database:", self.db_name_edit)
         main_layout.addLayout(form_layout)
 
         btn_box = QDialogButtonBox(
@@ -68,20 +74,36 @@ class DBConnectionDialog(QDialog):
 
     def load_settings(self) -> None:
         settings = QSettings("LegalAI", "Desktop")
+        self.db_type_combo.setCurrentText(settings.value("db/type", "PostgreSQL"))
         self.host_edit.setText(settings.value("db/host", "localhost"))
         self.port_edit.setText(settings.value("db/port", "5432"))
         self.user_edit.setText(settings.value("db/user", ""))
         self.password_edit.setText(settings.value("db/password", ""))
+        self.db_name_edit.setText(settings.value("db/name", "legal_ai"))
 
     def save_settings(self) -> None:
         settings = QSettings("LegalAI", "Desktop")
+        settings.setValue("db/type", self.db_type_combo.currentText())
         settings.setValue("db/host", self.host_edit.text())
         settings.setValue("db/port", self.port_edit.text())
         settings.setValue("db/user", self.user_edit.text())
         settings.setValue("db/password", self.password_edit.text())
+        settings.setValue("db/name", self.db_name_edit.text())
 
     def accept(self) -> None:  # type: ignore[override]
         self.save_settings()
+        if self.db_type_combo.currentText() == "PostgreSQL":
+            import os
+
+            os.environ["POSTGRES_HOST"] = self.host_edit.text()
+            os.environ["POSTGRES_PORT"] = self.port_edit.text()
+            os.environ["POSTGRES_USER"] = self.user_edit.text()
+            os.environ["POSTGRES_PASSWORD"] = self.password_edit.text()
+            os.environ["POSTGRES_DB"] = self.db_name_edit.text()
+            os.environ["DATABASE_URL"] = (
+                f"postgresql://{self.user_edit.text()}:{self.password_edit.text()}@"
+                f"{self.host_edit.text()}:{self.port_edit.text()}/{self.db_name_edit.text()}"
+            )
         super().accept()
 
 

--- a/legal_ai_system/tests/test_db_connection_dialog.py
+++ b/legal_ai_system/tests/test_db_connection_dialog.py
@@ -1,0 +1,41 @@
+import os
+import tempfile
+import unittest
+
+from PyQt6.QtCore import QSettings
+from PyQt6.QtWidgets import QApplication
+
+from legal_ai_system.gui.db_connection_dialog import DBConnectionDialog
+
+
+class DBConnectionDialogTest(unittest.TestCase):
+    def setUp(self):
+        self.app = QApplication.instance() or QApplication(["test", "-platform", "offscreen"])
+        self.temp_dir = tempfile.TemporaryDirectory()
+        QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope, self.temp_dir.name)
+
+    def tearDown(self):
+        self.app.quit()
+        self.temp_dir.cleanup()
+
+    def test_save_and_load(self):
+        dlg = DBConnectionDialog()
+        dlg.db_type_combo.setCurrentText("PostgreSQL")
+        dlg.host_edit.setText("example.com")
+        dlg.port_edit.setText("5432")
+        dlg.user_edit.setText("user")
+        dlg.password_edit.setText("pass")
+        dlg.db_name_edit.setText("legal")
+        dlg.save_settings()
+        del dlg
+        dlg2 = DBConnectionDialog()
+        self.assertEqual(dlg2.db_type_combo.currentText(), "PostgreSQL")
+        self.assertEqual(dlg2.host_edit.text(), "example.com")
+        self.assertEqual(dlg2.port_edit.text(), "5432")
+        self.assertEqual(dlg2.user_edit.text(), "user")
+        self.assertEqual(dlg2.password_edit.text(), "pass")
+        self.assertEqual(dlg2.db_name_edit.text(), "legal")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend `DBConnectionDialog` to handle PostgreSQL
- persist DB type and name
- update environment variables when saving
- document how to configure PostgreSQL from the GUI
- add unit test for the dialog

## Testing
- `nose2 -v legal_ai_system.tests.test_db_connection_dialog.DBConnectionDialogTest.test_save_and_load` *(fails: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b3fb410ec83239519e1182cbdb628