### PR TITLE
Add startup configuration dialog

### DIFF
--- a/legal_ai_system/gui/__init__.py
+++ b/legal_ai_system/gui/__init__.py
@@ -1,15 +1,28 @@
 """GUI components for the Legal AI System."""
 
-from .legal_ai_pyqt6_integrated import IntegratedMainWindow, main
-from .workflow_builder import (
-    DraggableComponentButton,
-    WorkflowCanvas,
-    WorkflowBuilderWidget,
-)
+def __getattr__(name):
+    if name == "IntegratedMainWindow":
+        from .legal_ai_pyqt6_integrated import IntegratedMainWindow
+        return IntegratedMainWindow
+    if name == "main":
+        from .legal_ai_pyqt6_integrated import main
+        return main
+    if name == "StartupConfigDialog":
+        from .startup_config_dialog import StartupConfigDialog
+        return StartupConfigDialog
+    if name in {"DraggableComponentButton", "WorkflowCanvas", "WorkflowBuilderWidget"}:
+        from .workflow_builder import (
+            DraggableComponentButton,
+            WorkflowCanvas,
+            WorkflowBuilderWidget,
+        )
+        return locals()[name]
+    raise AttributeError(name)
 
 __all__ = [
     "IntegratedMainWindow",
     "main",
+    "StartupConfigDialog",
     "DraggableComponentButton",
     "WorkflowCanvas",
     "WorkflowBuilderWidget",

--- a/legal_ai_system/gui/legal_ai_pyqt6_integrated.py
+++ b/legal_ai_system/gui/legal_ai_pyqt6_integrated.py
@@ -37,6 +37,7 @@ from legal_ai_system.legal_ai_network import (
 )
 
 from .backend_bridge import BackendBridge
+from .startup_config_dialog import StartupConfigDialog
 
 
 class GlowingButton(QPushButton):
@@ -1150,6 +1151,11 @@ class IntegratedMainWindow(QMainWindow):
 def main():
     # Create application
     app = LegalAIApplication(sys.argv)
+
+    # Display initial configuration dialog
+    setup_dialog = StartupConfigDialog()
+    if setup_dialog.exec() != QDialog.DialogCode.Accepted:
+        return
 
     # Create splash screen
     splash = QSplashScreen()

--- a/legal_ai_system/gui/startup_config_dialog.py
+++ b/legal_ai_system/gui/startup_config_dialog.py
@@ -1,0 +1,136 @@
+"""Startup configuration dialog for database and LLM settings."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from PyQt6.QtCore import QSettings
+from PyQt6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class StartupConfigDialog(QDialog):
+    """Collect database connection and LLM provider configuration."""
+
+    def __init__(self, parent: QDialog | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Initial Configuration")
+        self.resize(600, 400)
+
+        layout = QVBoxLayout(self)
+        self.tabs = QTabWidget()
+        layout.addWidget(self.tabs)
+
+        # Database tab -----------------------------------------------------
+        self.db_tab = QWidget()
+        db_layout = QFormLayout(self.db_tab)
+        self.db_type_combo = QComboBox()
+        self.db_type_combo.addItems(["PostgreSQL", "SQLite"])
+        db_layout.addRow("Type:", self.db_type_combo)
+        self.host_edit = QLineEdit()
+        self.port_edit = QLineEdit()
+        self.user_edit = QLineEdit()
+        self.password_edit = QLineEdit()
+        self.password_edit.setEchoMode(QLineEdit.EchoMode.Password)
+        self.db_name_edit = QLineEdit()
+        db_layout.addRow("Host:", self.host_edit)
+        db_layout.addRow("Port:", self.port_edit)
+        db_layout.addRow("User:", self.user_edit)
+        db_layout.addRow("Password:", self.password_edit)
+        db_layout.addRow("Database:", self.db_name_edit)
+        self.available_list = QListWidget()
+        db_layout.addRow(QLabel("Detected SQLite DBs:"), self.available_list)
+        self.tabs.addTab(self.db_tab, "Database")
+
+        # LLM tab ----------------------------------------------------------
+        self.llm_tab = QWidget()
+        llm_layout = QFormLayout(self.llm_tab)
+        self.llm_provider_combo = QComboBox()
+        self.llm_provider_combo.addItems(["openai", "xai", "ollama"])
+        llm_layout.addRow("Provider:", self.llm_provider_combo)
+        self.api_key_edit = QLineEdit()
+        self.api_key_edit.setEchoMode(QLineEdit.EchoMode.Password)
+        llm_layout.addRow("API Key:", self.api_key_edit)
+        self.tabs.addTab(self.llm_tab, "LLM Provider")
+
+        # Buttons ----------------------------------------------------------
+        btn_box = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok
+            | QDialogButtonBox.StandardButton.Cancel
+        )
+        btn_box.accepted.connect(self.accept)
+        btn_box.rejected.connect(self.reject)
+        layout.addWidget(btn_box)
+
+        self.load_settings()
+        self.populate_databases()
+        self._provider_changed(self.llm_provider_combo.currentText())
+        self.llm_provider_combo.currentTextChanged.connect(self._provider_changed)
+
+    # ------------------------------------------------------------------
+    def populate_databases(self) -> None:
+        """List available SQLite databases in the project directory."""
+        self.available_list.clear()
+        for path in Path.cwd().rglob("*.db"):
+            self.available_list.addItem(str(path))
+
+    def _provider_changed(self, provider: str) -> None:
+        self.api_key_edit.setEnabled(provider in {"openai", "xai"})
+
+    def load_settings(self) -> None:
+        settings = QSettings("LegalAI", "Desktop")
+        self.db_type_combo.setCurrentText(settings.value("db/type", "PostgreSQL"))
+        self.host_edit.setText(settings.value("db/host", "localhost"))
+        self.port_edit.setText(settings.value("db/port", "5432"))
+        self.user_edit.setText(settings.value("db/user", ""))
+        self.password_edit.setText(settings.value("db/password", ""))
+        self.db_name_edit.setText(settings.value("db/name", "legal_ai"))
+        provider = settings.value("llm/provider", "openai")
+        self.llm_provider_combo.setCurrentText(provider)
+        self.api_key_edit.setText(settings.value(f"llm/{provider}_api_key", ""))
+
+    def save_settings(self) -> None:
+        settings = QSettings("LegalAI", "Desktop")
+        settings.setValue("db/type", self.db_type_combo.currentText())
+        settings.setValue("db/host", self.host_edit.text())
+        settings.setValue("db/port", self.port_edit.text())
+        settings.setValue("db/user", self.user_edit.text())
+        settings.setValue("db/password", self.password_edit.text())
+        settings.setValue("db/name", self.db_name_edit.text())
+        provider = self.llm_provider_combo.currentText()
+        settings.setValue("llm/provider", provider)
+        settings.setValue(f"llm/{provider}_api_key", self.api_key_edit.text())
+
+    def accept(self) -> None:  # type: ignore[override]
+        self.save_settings()
+        if self.db_type_combo.currentText() == "PostgreSQL":
+            os.environ["POSTGRES_HOST"] = self.host_edit.text()
+            os.environ["POSTGRES_PORT"] = self.port_edit.text()
+            os.environ["POSTGRES_USER"] = self.user_edit.text()
+            os.environ["POSTGRES_PASSWORD"] = self.password_edit.text()
+            os.environ["POSTGRES_DB"] = self.db_name_edit.text()
+            os.environ["DATABASE_URL"] = (
+                f"postgresql://{self.user_edit.text()}:{self.password_edit.text()}@"
+                f"{self.host_edit.text()}:{self.port_edit.text()}/{self.db_name_edit.text()}"
+            )
+        provider = self.llm_provider_combo.currentText()
+        os.environ["LLM_PROVIDER"] = provider
+        if provider == "openai":
+            os.environ["OPENAI_API_KEY"] = self.api_key_edit.text()
+        elif provider == "xai":
+            os.environ["XAI_API_KEY"] = self.api_key_edit.text()
+        super().accept()
+
+
+__all__ = ["StartupConfigDialog"]

--- a/legal_ai_system/tests/test_startup_config_dialog.py
+++ b/legal_ai_system/tests/test_startup_config_dialog.py
@@ -1,0 +1,41 @@
+import os
+import tempfile
+import unittest
+
+from PyQt6.QtCore import QSettings
+from PyQt6.QtWidgets import QApplication
+
+from legal_ai_system.gui.startup_config_dialog import StartupConfigDialog
+
+
+class StartupConfigDialogTest(unittest.TestCase):
+    def setUp(self):
+        self.app = QApplication.instance() or QApplication(["test", "-platform", "offscreen"])
+        self.temp_dir = tempfile.TemporaryDirectory()
+        QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope, self.temp_dir.name)
+
+    def tearDown(self):
+        self.app.quit()
+        self.temp_dir.cleanup()
+
+    def test_save_and_env_vars(self):
+        dlg = StartupConfigDialog()
+        dlg.db_type_combo.setCurrentText("PostgreSQL")
+        dlg.host_edit.setText("db.example.com")
+        dlg.port_edit.setText("5432")
+        dlg.user_edit.setText("user")
+        dlg.password_edit.setText("pass")
+        dlg.db_name_edit.setText("legal")
+        dlg.llm_provider_combo.setCurrentText("openai")
+        dlg.api_key_edit.setText("key123")
+        dlg.save_settings()
+        dlg.accept()
+        self.assertEqual(os.environ.get("OPENAI_API_KEY"), "key123")
+        self.assertEqual(os.environ.get("LLM_PROVIDER"), "openai")
+        dlg2 = StartupConfigDialog()
+        self.assertEqual(dlg2.llm_provider_combo.currentText(), "openai")
+        self.assertEqual(dlg2.api_key_edit.text(), "key123")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `StartupConfigDialog` to configure database and LLM
- import dialog in GUI init lazily
- launch dialog before showing splash screen
- test startup config settings

## Testing
- `QT_QPA_PLATFORM=offscreen nose2 -v legal_ai_system.tests.test_startup_config_dialog.StartupConfigDialogTest.test_save_and_env_vars`
- `QT_QPA_PLATFORM=offscreen nose2 -v` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b658d742c8323bda52c27c41fbee2