### PR TITLE
Update GUI launch docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,11 @@ initialises the asynchronous service container and forwards all actions to the
 `LegalAIIntegrationService`. Progress updates are emitted back to the widgets in
 real time.
 
-```python
-from legal_ai_system.gui import IntegratedMainWindow
 
-window = IntegratedMainWindow()
-window.show()
+Launch the interface using the package entry point:
+
+```bash
+python -m legal_ai_system
 ```
 
 The bridge ensures the desktop app communicates with the same backend services


### PR DESCRIPTION
## Summary
- update README instructions for starting the PyQt6 GUI to use the package entry point

## Testing
- `nose2 -s legal_ai_system/tests` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_684b891116e08323be095eba8dbbd49e