### PR TITLE
Fix test runner references

### DIFF
--- a/legal_ai_system/docs/developer_onboarding.md
+++ b/legal_ai_system/docs/developer_onboarding.md
@@ -36,10 +36,11 @@ Welcome to the Legal AI System project! This guide helps new contributors set up
    [ENV_SETUP.md](ENV_SETUP.md). Install them as needed.
 
 ## Running Tests
-Tests use **pytest**. After installing the `dev` dependencies:
+Tests use **nose2** on top of the standard `unittest` framework. After
+installing the `dev` dependencies run `nose2` directly:
 ```bash
 pip install -e .[dev]
-pytest
+nose2
 ```
 See [docs/test_setup.md](test_setup.md) for details.
 
@@ -50,7 +51,7 @@ See [docs/test_setup.md](test_setup.md) for details.
    black .
    isort .
    ```
-3. Run `pytest` to verify that all tests pass.
+3. Run `nose2` to verify that all tests pass.
 4. Commit your work and open a pull request.
 
 ## Additional Resources

--- a/legal_ai_system/scripts/install_all_dependencies.py
+++ b/legal_ai_system/scripts/install_all_dependencies.py
@@ -48,9 +48,9 @@ def verify_imports(venv_path: Path) -> None:
 
 
 def run_tests(venv_path: Path) -> None:
-    """Run pytest using the virtual environment."""
+    """Run nose2 using the virtual environment."""
     python_exe = venv_path / "bin" / "python"
-    run([str(python_exe), "-m", "pytest"])
+    run([str(python_exe), "-m", "nose2"])
 
 
 def main() -> None:

--- a/legal_ai_system/scripts/setup_environment_task.py
+++ b/legal_ai_system/scripts/setup_environment_task.py
@@ -44,9 +44,9 @@ def verify_imports(venv_path: Path) -> None:
 
 
 def run_tests(venv_path: Path) -> None:
-    """Run the project's pytest suite."""
+    """Run the project's nose2 test suite."""
     python_exe = venv_path / "bin" / "python"
-    run([str(python_exe), "-m", "pytest"])
+    run([str(python_exe), "-m", "nose2"])
 
 
 def main() -> None:

--- a/legal_ai_system/scripts/start_linkage_check.py
+++ b/legal_ai_system/scripts/start_linkage_check.py
@@ -29,7 +29,7 @@ def main() -> None:
     except Exception as exc:  # pragma: no cover - best effort
         print(f"Health check failed: {exc}")
 
-    run([python_exe, "-m", "pytest", str(repo_root / "legal_ai_system" / "tests")])
+    run([python_exe, "-m", "nose2", str(repo_root / "legal_ai_system" / "tests")])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- standardize docs and helper scripts on using `nose2`
- update onboarding guide to mention `nose2`
- modify helper scripts to invoke `nose2` instead of `pytest`

## Testing
- `nose2 2>&1 | head`

------
https://chatgpt.com/codex/tasks/task_e_684b8b4b27fc8323bc1d178100493733