### PR TITLE
Fix module import for integration_ready

### DIFF
--- a/legal_ai_system/integration_ready/__init__.py
+++ b/legal_ai_system/integration_ready/__init__.py
@@ -1,0 +1,5 @@
+"""Compatibility wrappers for legacy imports."""
+
+from .vector_store_enhanced import MemoryStore, EmbeddingClient
+
+__all__ = ["MemoryStore", "EmbeddingClient"]


### PR DESCRIPTION
## Summary
- add missing `__init__.py` for `integration_ready`
- export compatibility wrappers

## Testing
- `nose2 -v legal_ai_system.tests.test_integration_service_upload` *(fails: ModuleNotFoundError: No module named 'aiofiles')*
- `nose2 -v` *(fails to import several modules including PyQt6 and typer)*

------
https://chatgpt.com/codex/tasks/task_e_684b90a80b18832399dd31061c74166b