### PR TITLE
Fix relative imports for memory_manager and embedding_manager

### DIFF
--- a/legal_ai_system/core/embedding_manager.py
+++ b/legal_ai_system/core/embedding_manager.py
@@ -13,7 +13,9 @@ from typing import Dict, List, Any
 from pathlib import Path
 import threading
 
-from legal_ai_system.integration_ready.vector_store_enhanced import EmbeddingClient
+# Resolve the embedding client relative to this package so the module can be
+# executed directly from the repository without installing ``legal_ai_system``.
+from ..integration_ready.vector_store_enhanced import EmbeddingClient
 
 logger = logging.getLogger(__name__)
 

--- a/legal_ai_system/services/memory_manager.py
+++ b/legal_ai_system/services/memory_manager.py
@@ -13,7 +13,13 @@ from typing import Any, Dict, List, Optional
 from pathlib import Path
 import threading
 
-from legal_ai_system.integration_ready.vector_store_enhanced import MemoryStore
+# Use a relative import so the package works even if the repository hasn't been
+# installed as a site package.  Windows users reported ``ModuleNotFoundError``
+# when the absolute import was used directly from the source tree.  By
+# resolving the dependency relative to this module we ensure the correct
+# ``integration_ready`` package is found regardless of how ``legal_ai_system``
+# is executed.
+from ..integration_ready.vector_store_enhanced import MemoryStore
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- resolve `integration_ready` imports via relative paths so source tree works without installation

## Testing
- `python -m legal_ai_system` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684b91fc18b483238e1f610bae72e49d